### PR TITLE
✨feat: 3주차 — API 명세서 16개 작성 + Swagger Docs 인터페이스 패턴 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,12 @@ dependencies {
 	// Spring Data JPA
 	implementation 'org.springframework.data:spring-data-jpa'
 
+	// Validation (Jakarta Bean Validation)
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// Springdoc OpenAPI (Swagger)
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'
+
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/project/likelion14thbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/controller/MemberController.java
@@ -1,7 +1,76 @@
 package com.project.likelion14thbe.domain.member.controller;
 
+import com.project.likelion14thbe.domain.member.controller.docs.MemberDocs;
+import com.project.likelion14thbe.domain.member.dto.request.MemberReqDTO;
+import com.project.likelion14thbe.domain.member.dto.response.MemberResDTO;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-public class MemberController {
+@RequestMapping("/api/v1")
+public class MemberController implements MemberDocs {
+
+    @Override
+    @PostMapping("/members")
+    public ResponseEntity<MemberResDTO.SignUpResDTO> signUp(
+            @Valid @RequestBody MemberReqDTO.SignUpReqDTO request
+    ) {
+        MemberResDTO.SignUpResDTO body = new MemberResDTO.SignUpResDTO(
+                1L,
+                request.email(),
+                request.nickname(),
+                LocalDateTime.now()
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(body);
+    }
+
+    @Override
+    @PostMapping("/auth/login")
+    public ResponseEntity<MemberResDTO.LoginResDTO> login(
+            @Valid @RequestBody MemberReqDTO.LoginReqDTO request
+    ) {
+        MemberResDTO.LoginResDTO body = new MemberResDTO.LoginResDTO(
+                1L,
+                "bro",
+                "eyJhbGciOiJIUzI1NiJ9.dummy.access",
+                "eyJhbGciOiJIUzI1NiJ9.dummy.refresh",
+                3600L
+        );
+        return ResponseEntity.ok(body);
+    }
+
+    @Override
+    @PostMapping("/auth/kakao/login")
+    public ResponseEntity<MemberResDTO.KakaoLoginResDTO> kakaoLogin(
+            @Valid @RequestBody MemberReqDTO.KakaoLoginReqDTO request
+    ) {
+        MemberResDTO.KakaoLoginResDTO body = new MemberResDTO.KakaoLoginResDTO(
+                1L,
+                "bro",
+                "eyJhbGciOiJIUzI1NiJ9.dummy.access",
+                "eyJhbGciOiJIUzI1NiJ9.dummy.refresh",
+                false
+        );
+        return ResponseEntity.ok(body);
+    }
+
+    @Override
+    @PatchMapping("/members/me/password")
+    public ResponseEntity<MemberResDTO.UpdatePasswordResDTO> updatePassword(
+            @Valid @RequestBody MemberReqDTO.UpdatePasswordReqDTO request
+    ) {
+        MemberResDTO.UpdatePasswordResDTO body = new MemberResDTO.UpdatePasswordResDTO(
+                1L,
+                LocalDateTime.now()
+        );
+        return ResponseEntity.ok(body);
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/member/controller/docs/MemberDocs.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/controller/docs/MemberDocs.java
@@ -1,0 +1,65 @@
+package com.project.likelion14thbe.domain.member.controller.docs;
+
+import com.project.likelion14thbe.domain.member.dto.request.MemberReqDTO;
+import com.project.likelion14thbe.domain.member.dto.response.MemberResDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Member", description = "회원 API — 회원가입, 로그인(일반/카카오), 비밀번호 수정")
+public interface MemberDocs {
+
+    @Operation(
+            summary = "회원가입",
+            description = "이메일·비밀번호·닉네임으로 신규 회원을 등록한다. 이메일·닉네임 중복 시 409."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "회원가입 성공",
+                    content = @Content(schema = @Schema(implementation = MemberResDTO.SignUpResDTO.class))),
+            @ApiResponse(responseCode = "400", description = "입력 형식 오류 (이메일/비밀번호/닉네임)", content = @Content),
+            @ApiResponse(responseCode = "409", description = "이미 가입된 이메일 또는 닉네임", content = @Content)
+    })
+    ResponseEntity<MemberResDTO.SignUpResDTO> signUp(MemberReqDTO.SignUpReqDTO request);
+
+    @Operation(
+            summary = "일반 로그인",
+            description = "이메일·비밀번호로 로그인 후 JWT Access/Refresh 토큰을 발급한다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공",
+                    content = @Content(schema = @Schema(implementation = MemberResDTO.LoginResDTO.class))),
+            @ApiResponse(responseCode = "401", description = "이메일 또는 비밀번호 불일치", content = @Content),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 회원", content = @Content)
+    })
+    ResponseEntity<MemberResDTO.LoginResDTO> login(MemberReqDTO.LoginReqDTO request);
+
+    @Operation(
+            summary = "카카오 로그인",
+            description = "프론트에서 받은 카카오 OAuth Access Token을 검증하고 자체 JWT 토큰을 발급한다. 첫 로그인 시 자동 회원가입."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "카카오 로그인 성공",
+                    content = @Content(schema = @Schema(implementation = MemberResDTO.KakaoLoginResDTO.class))),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 카카오 토큰", content = @Content),
+            @ApiResponse(responseCode = "502", description = "카카오 인증 서버 통신 실패", content = @Content)
+    })
+    ResponseEntity<MemberResDTO.KakaoLoginResDTO> kakaoLogin(MemberReqDTO.KakaoLoginReqDTO request);
+
+    @Operation(
+            summary = "비밀번호 수정",
+            description = "현재 로그인한 회원의 비밀번호를 변경한다. 현재 비밀번호 검증 필요."
+    )
+    @SecurityRequirement(name = "JWT TOKEN")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공",
+                    content = @Content(schema = @Schema(implementation = MemberResDTO.UpdatePasswordResDTO.class))),
+            @ApiResponse(responseCode = "400", description = "현재 비밀번호 불일치 또는 새 비밀번호 형식 오류", content = @Content),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content)
+    })
+    ResponseEntity<MemberResDTO.UpdatePasswordResDTO> updatePassword(MemberReqDTO.UpdatePasswordReqDTO request);
+}

--- a/src/main/java/com/project/likelion14thbe/domain/member/dto/request/MemberReqDTO.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/dto/request/MemberReqDTO.java
@@ -1,4 +1,63 @@
 package com.project.likelion14thbe.domain.member.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public class MemberReqDTO {
+
+    @Schema(description = "회원가입 요청 DTO")
+    public record SignUpReqDTO(
+            @Schema(description = "이메일", example = "user@example.com")
+            @NotBlank(message = "이메일은 필수입니다.")
+            @Email(message = "올바른 이메일 형식이 아닙니다.")
+            String email,
+
+            @Schema(description = "비밀번호 (최소 8자)", example = "passw0rd!!")
+            @NotBlank(message = "비밀번호는 필수입니다.")
+            @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+            String password,
+
+            @Schema(description = "닉네임 (2~20자)", example = "bro")
+            @NotBlank(message = "닉네임은 필수입니다.")
+            @Size(min = 2, max = 20, message = "닉네임은 2자 이상 20자 이하여야 합니다.")
+            String nickname
+    ) {
+    }
+
+    @Schema(description = "일반 로그인 요청 DTO")
+    public record LoginReqDTO(
+            @Schema(description = "이메일", example = "user@example.com")
+            @NotBlank(message = "이메일은 필수입니다.")
+            @Email(message = "올바른 이메일 형식이 아닙니다.")
+            String email,
+
+            @Schema(description = "비밀번호", example = "passw0rd!!")
+            @NotBlank(message = "비밀번호는 필수입니다.")
+            String password
+    ) {
+    }
+
+    @Schema(description = "카카오 로그인 요청 DTO")
+    public record KakaoLoginReqDTO(
+            @Schema(description = "카카오 OAuth Access Token (프론트에서 발급받아 전달)",
+                    example = "kakao_access_token_value")
+            @NotBlank(message = "카카오 액세스 토큰은 필수입니다.")
+            String accessToken
+    ) {
+    }
+
+    @Schema(description = "비밀번호 수정 요청 DTO")
+    public record UpdatePasswordReqDTO(
+            @Schema(description = "현재 비밀번호", example = "passw0rd!!")
+            @NotBlank(message = "현재 비밀번호는 필수입니다.")
+            String currentPassword,
+
+            @Schema(description = "새 비밀번호 (최소 8자)", example = "newPassw0rd!!")
+            @NotBlank(message = "새 비밀번호는 필수입니다.")
+            @Size(min = 8, message = "새 비밀번호는 8자 이상이어야 합니다.")
+            String newPassword
+    ) {
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/member/dto/response/MemberResDTO.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/dto/response/MemberResDTO.java
@@ -1,4 +1,72 @@
 package com.project.likelion14thbe.domain.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
 public class MemberResDTO {
+
+    @Schema(description = "회원가입 응답 DTO")
+    public record SignUpResDTO(
+            @Schema(description = "회원 ID", example = "1")
+            Long memberId,
+
+            @Schema(description = "이메일", example = "user@example.com")
+            String email,
+
+            @Schema(description = "닉네임", example = "bro")
+            String nickname,
+
+            @Schema(description = "가입 일시", example = "2026-04-29T10:00:00")
+            LocalDateTime createdAt
+    ) {
+    }
+
+    @Schema(description = "일반 로그인 응답 DTO")
+    public record LoginResDTO(
+            @Schema(description = "회원 ID", example = "1")
+            Long memberId,
+
+            @Schema(description = "닉네임", example = "bro")
+            String nickname,
+
+            @Schema(description = "JWT Access Token", example = "eyJhbGciOi...")
+            String accessToken,
+
+            @Schema(description = "JWT Refresh Token", example = "eyJhbGciOi...")
+            String refreshToken,
+
+            @Schema(description = "Access Token 만료 시간(초)", example = "3600")
+            Long expiresIn
+    ) {
+    }
+
+    @Schema(description = "카카오 로그인 응답 DTO")
+    public record KakaoLoginResDTO(
+            @Schema(description = "회원 ID", example = "1")
+            Long memberId,
+
+            @Schema(description = "닉네임", example = "bro")
+            String nickname,
+
+            @Schema(description = "JWT Access Token", example = "eyJhbGciOi...")
+            String accessToken,
+
+            @Schema(description = "JWT Refresh Token", example = "eyJhbGciOi...")
+            String refreshToken,
+
+            @Schema(description = "신규 회원 여부 (카카오 첫 로그인 시 true)", example = "false")
+            Boolean isNewMember
+    ) {
+    }
+
+    @Schema(description = "비밀번호 수정 응답 DTO")
+    public record UpdatePasswordResDTO(
+            @Schema(description = "회원 ID", example = "1")
+            Long memberId,
+
+            @Schema(description = "수정 일시", example = "2026-04-29T10:30:00")
+            LocalDateTime updatedAt
+    ) {
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/repository/MemberRepository.java
@@ -1,9 +1,4 @@
 package com.project.likelion14thbe.domain.member.repository;
 
-import com.project.likelion14thbe.domain.member.entity.Member;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository {
 }

--- a/src/main/java/com/project/likelion14thbe/domain/order/controller/OrderController.java
+++ b/src/main/java/com/project/likelion14thbe/domain/order/controller/OrderController.java
@@ -1,7 +1,56 @@
 package com.project.likelion14thbe.domain.order.controller;
 
+import com.project.likelion14thbe.domain.order.controller.docs.OrderDocs;
+import com.project.likelion14thbe.domain.order.dto.request.OrderReqDTO;
+import com.project.likelion14thbe.domain.order.dto.response.OrderResDTO;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-public class OrderController {
+@RequestMapping("/api/v1")
+public class OrderController implements OrderDocs {
+
+    @Override
+    @PostMapping("/orders")
+    public ResponseEntity<OrderResDTO.CreateOrderResDTO> createOrder(
+            @Valid @RequestBody OrderReqDTO.CreateOrderReqDTO request
+    ) {
+        int totalPrice = request.quantity() * 3000;
+        OrderResDTO.CreateOrderResDTO body = new OrderResDTO.CreateOrderResDTO(
+                100L,
+                request.productId(),
+                request.quantity(),
+                totalPrice,
+                "PENDING",
+                LocalDateTime.now()
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(body);
+    }
+
+    @Override
+    @GetMapping("/members/me/orders")
+    public ResponseEntity<OrderResDTO.MyOrderListResDTO> getMyOrders(
+            @RequestParam(defaultValue = "0") Integer page,
+            @RequestParam(defaultValue = "10") Integer size
+    ) {
+        List<OrderResDTO.MyOrderItemDTO> orderList = List.of(
+                new OrderResDTO.MyOrderItemDTO(
+                        100L, 5L, "사과", 2, 6000, "DELIVERED", LocalDateTime.now()
+                )
+        );
+        OrderResDTO.MyOrderListResDTO body = new OrderResDTO.MyOrderListResDTO(
+                12L, 2, page, size, false, orderList
+        );
+        return ResponseEntity.ok(body);
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/order/controller/docs/OrderDocs.java
+++ b/src/main/java/com/project/likelion14thbe/domain/order/controller/docs/OrderDocs.java
@@ -1,0 +1,48 @@
+package com.project.likelion14thbe.domain.order.controller.docs;
+
+import com.project.likelion14thbe.domain.order.dto.request.OrderReqDTO;
+import com.project.likelion14thbe.domain.order.dto.response.OrderResDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Order", description = "주문 API — 주문 생성, 내 주문 목록 조회")
+@SecurityRequirement(name = "JWT TOKEN")
+public interface OrderDocs {
+
+    @Operation(
+            summary = "주문 생성",
+            description = "현재 로그인한 회원이 특정 상품을 주문한다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "주문 생성 성공",
+                    content = @Content(schema = @Schema(implementation = OrderResDTO.CreateOrderResDTO.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 수량 또는 입력 형식 오류", content = @Content),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
+            @ApiResponse(responseCode = "404", description = "상품이 존재하지 않음", content = @Content)
+    })
+    ResponseEntity<OrderResDTO.CreateOrderResDTO> createOrder(
+            OrderReqDTO.CreateOrderReqDTO request
+    );
+
+    @Operation(
+            summary = "내 주문 목록 조회",
+            description = "현재 로그인한 회원의 모든 주문을 페이징 조회한다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "내 주문 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = OrderResDTO.MyOrderListResDTO.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 페이지 파라미터", content = @Content),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content)
+    })
+    ResponseEntity<OrderResDTO.MyOrderListResDTO> getMyOrders(
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") Integer page,
+            @Parameter(description = "페이지당 개수", example = "10") Integer size
+    );
+}

--- a/src/main/java/com/project/likelion14thbe/domain/order/dto/request/OrderReqDTO.java
+++ b/src/main/java/com/project/likelion14thbe/domain/order/dto/request/OrderReqDTO.java
@@ -1,4 +1,26 @@
 package com.project.likelion14thbe.domain.order.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public class OrderReqDTO {
+
+    @Schema(description = "주문 생성 요청 DTO")
+    public record CreateOrderReqDTO(
+            @Schema(description = "주문할 상품 아이디", example = "5")
+            @NotNull(message = "상품 아이디는 필수입니다.")
+            Long productId,
+
+            @Schema(description = "수량 (1 이상)", example = "2")
+            @NotNull(message = "수량은 필수입니다.")
+            @Min(value = 1, message = "수량은 1 이상이어야 합니다.")
+            Integer quantity,
+
+            @Schema(description = "배송 주소", example = "서울특별시 종로구 ...")
+            @NotBlank(message = "배송 주소는 필수입니다.")
+            String address
+    ) {
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/order/dto/response/OrderResDTO.java
+++ b/src/main/java/com/project/likelion14thbe/domain/order/dto/response/OrderResDTO.java
@@ -1,4 +1,79 @@
 package com.project.likelion14thbe.domain.order.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
 public class OrderResDTO {
+
+    @Schema(description = "주문 생성 응답 DTO")
+    public record CreateOrderResDTO(
+            @Schema(description = "주문 ID", example = "100")
+            Long orderId,
+
+            @Schema(description = "상품 ID", example = "5")
+            Long productId,
+
+            @Schema(description = "수량", example = "2")
+            Integer quantity,
+
+            @Schema(description = "총 결제 금액", example = "6000")
+            Integer totalPrice,
+
+            @Schema(description = "주문 상태", example = "PENDING",
+                    allowableValues = {"PENDING", "PAID", "DELIVERED", "CANCELLED"})
+            String status,
+
+            @Schema(description = "주문 일시", example = "2026-04-29T12:00:00")
+            LocalDateTime createdAt
+    ) {
+    }
+
+    @Schema(description = "내 주문 목록 — 개별 주문 아이템")
+    public record MyOrderItemDTO(
+            @Schema(description = "주문 ID", example = "100")
+            Long orderId,
+
+            @Schema(description = "상품 ID", example = "5")
+            Long productId,
+
+            @Schema(description = "상품명", example = "사과")
+            String productName,
+
+            @Schema(description = "수량", example = "2")
+            Integer quantity,
+
+            @Schema(description = "총 결제 금액", example = "6000")
+            Integer totalPrice,
+
+            @Schema(description = "주문 상태", example = "DELIVERED")
+            String status,
+
+            @Schema(description = "주문 일시", example = "2026-04-29T12:00:00")
+            LocalDateTime createdAt
+    ) {
+    }
+
+    @Schema(description = "내 주문 목록 응답 DTO (페이징 포함)")
+    public record MyOrderListResDTO(
+            @Schema(description = "전체 주문 개수", example = "12")
+            Long totalElements,
+
+            @Schema(description = "전체 페이지 수", example = "2")
+            Integer totalPages,
+
+            @Schema(description = "현재 페이지 번호 (0부터 시작)", example = "0")
+            Integer currentPage,
+
+            @Schema(description = "페이지당 개수", example = "10")
+            Integer size,
+
+            @Schema(description = "마지막 페이지 여부", example = "false")
+            Boolean isLast,
+
+            @Schema(description = "내 주문 목록")
+            List<MyOrderItemDTO> orderList
+    ) {
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/project/likelion14thbe/domain/order/repository/OrderRepository.java
@@ -1,9 +1,4 @@
 package com.project.likelion14thbe.domain.order.repository;
 
-import com.project.likelion14thbe.domain.order.entity.Order;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface OrderRepository extends JpaRepository<Order, Long> {
+public interface OrderRepository {
 }

--- a/src/main/java/com/project/likelion14thbe/domain/product/controller/ProductController.java
+++ b/src/main/java/com/project/likelion14thbe/domain/product/controller/ProductController.java
@@ -1,7 +1,89 @@
 package com.project.likelion14thbe.domain.product.controller;
 
+import com.project.likelion14thbe.domain.product.controller.docs.ProductDocs;
+import com.project.likelion14thbe.domain.product.dto.request.ProductReqDTO;
+import com.project.likelion14thbe.domain.product.dto.response.ProductResDTO;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-public class ProductController {
+@RequestMapping("/api/v1/products")
+public class ProductController implements ProductDocs {
+
+    @Override
+    @GetMapping
+    public ResponseEntity<ProductResDTO.ProductListResDTO> getProductList(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String category,
+            @RequestParam(defaultValue = "0") Integer page,
+            @RequestParam(defaultValue = "10") Integer size
+    ) {
+        List<ProductResDTO.ProductItemDTO> productList = List.of(
+                new ProductResDTO.ProductItemDTO(
+                        1L, "사과", 3000, "과일", "https://example.com/thumb/1.jpg"
+                ),
+                new ProductResDTO.ProductItemDTO(
+                        2L, "바나나", 2000, "과일", "https://example.com/thumb/2.jpg"
+                )
+        );
+        ProductResDTO.ProductListResDTO body = new ProductResDTO.ProductListResDTO(
+                50L, 5, page, size, false, productList
+        );
+        return ResponseEntity.ok(body);
+    }
+
+    @Override
+    @GetMapping("/{productId}")
+    public ResponseEntity<ProductResDTO.ProductDetailResDTO> getProduct(
+            @PathVariable Long productId
+    ) {
+        ProductResDTO.ProductDetailResDTO body = new ProductResDTO.ProductDetailResDTO(
+                productId,
+                "사과",
+                3000,
+                "과일",
+                "신선한 사과입니다.",
+                "https://example.com/thumb/1.jpg",
+                LocalDateTime.now()
+        );
+        return ResponseEntity.ok(body);
+    }
+
+    @Override
+    @PostMapping
+    public ResponseEntity<ProductResDTO.CreateProductResDTO> createProduct(
+            @Valid @RequestBody ProductReqDTO.CreateProductReqDTO request
+    ) {
+        ProductResDTO.CreateProductResDTO body = new ProductResDTO.CreateProductResDTO(
+                51L,
+                request.name(),
+                request.price(),
+                LocalDateTime.now()
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(body);
+    }
+
+    @Override
+    @DeleteMapping("/{productId}")
+    public ResponseEntity<ProductResDTO.DeleteProductResDTO> deleteProduct(
+            @PathVariable Long productId
+    ) {
+        ProductResDTO.DeleteProductResDTO body = new ProductResDTO.DeleteProductResDTO(
+                productId,
+                LocalDateTime.now()
+        );
+        return ResponseEntity.ok(body);
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/product/controller/docs/ProductDocs.java
+++ b/src/main/java/com/project/likelion14thbe/domain/product/controller/docs/ProductDocs.java
@@ -1,0 +1,78 @@
+package com.project.likelion14thbe.domain.product.controller.docs;
+
+import com.project.likelion14thbe.domain.product.dto.request.ProductReqDTO;
+import com.project.likelion14thbe.domain.product.dto.response.ProductResDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Product", description = "상품 API — 목록/상세 조회, 추가, 삭제")
+public interface ProductDocs {
+
+    @Operation(
+            summary = "상품 목록 조회",
+            description = "상품 목록을 페이징 조회한다. 키워드/카테고리 필터 지원."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "상품 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = ProductResDTO.ProductListResDTO.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 페이지 파라미터", content = @Content)
+    })
+    ResponseEntity<ProductResDTO.ProductListResDTO> getProductList(
+            @Parameter(description = "상품명 검색어 (선택)", example = "사과") String keyword,
+            @Parameter(description = "카테고리 필터 (선택)", example = "과일") String category,
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") Integer page,
+            @Parameter(description = "페이지당 개수", example = "10") Integer size
+    );
+
+    @Operation(
+            summary = "상품 상세 조회",
+            description = "특정 상품의 상세 정보를 조회한다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "상품 상세 조회 성공",
+                    content = @Content(schema = @Schema(implementation = ProductResDTO.ProductDetailResDTO.class))),
+            @ApiResponse(responseCode = "404", description = "상품이 존재하지 않음", content = @Content)
+    })
+    ResponseEntity<ProductResDTO.ProductDetailResDTO> getProduct(
+            @Parameter(description = "상품 아이디", example = "1") Long productId
+    );
+
+    @Operation(
+            summary = "상품 추가",
+            description = "신규 상품을 등록한다. 관리자 권한 필요."
+    )
+    @SecurityRequirement(name = "JWT TOKEN")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "상품 등록 성공",
+                    content = @Content(schema = @Schema(implementation = ProductResDTO.CreateProductResDTO.class))),
+            @ApiResponse(responseCode = "400", description = "입력 형식 오류", content = @Content),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음", content = @Content)
+    })
+    ResponseEntity<ProductResDTO.CreateProductResDTO> createProduct(
+            ProductReqDTO.CreateProductReqDTO request
+    );
+
+    @Operation(
+            summary = "상품 삭제",
+            description = "특정 상품을 삭제한다. 관리자 권한 필요."
+    )
+    @SecurityRequirement(name = "JWT TOKEN")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "상품 삭제 성공",
+                    content = @Content(schema = @Schema(implementation = ProductResDTO.DeleteProductResDTO.class))),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음", content = @Content),
+            @ApiResponse(responseCode = "404", description = "상품이 존재하지 않음", content = @Content)
+    })
+    ResponseEntity<ProductResDTO.DeleteProductResDTO> deleteProduct(
+            @Parameter(description = "상품 아이디", example = "51") Long productId
+    );
+}

--- a/src/main/java/com/project/likelion14thbe/domain/product/dto/request/ProductReqDTO.java
+++ b/src/main/java/com/project/likelion14thbe/domain/product/dto/request/ProductReqDTO.java
@@ -1,4 +1,31 @@
 package com.project.likelion14thbe.domain.product.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 public class ProductReqDTO {
+
+    @Schema(description = "상품 추가 요청 DTO")
+    public record CreateProductReqDTO(
+            @Schema(description = "상품명", example = "바나나")
+            @NotBlank(message = "상품명은 필수입니다.")
+            @Size(max = 100, message = "상품명은 100자 이하여야 합니다.")
+            String name,
+
+            @Schema(description = "가격 (0 이상)", example = "2000")
+            @NotNull(message = "가격은 필수입니다.")
+            @Min(value = 0, message = "가격은 0 이상이어야 합니다.")
+            Integer price,
+
+            @Schema(description = "카테고리", example = "과일")
+            @NotBlank(message = "카테고리는 필수입니다.")
+            String category,
+
+            @Schema(description = "상품 설명", example = "달콤한 바나나")
+            String description
+    ) {
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/product/dto/response/ProductResDTO.java
+++ b/src/main/java/com/project/likelion14thbe/domain/product/dto/response/ProductResDTO.java
@@ -1,4 +1,101 @@
 package com.project.likelion14thbe.domain.product.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
 public class ProductResDTO {
+
+    @Schema(description = "상품 목록 조회 — 개별 상품 아이템")
+    public record ProductItemDTO(
+            @Schema(description = "상품 ID", example = "1")
+            Long productId,
+
+            @Schema(description = "상품명", example = "사과")
+            String name,
+
+            @Schema(description = "가격", example = "3000")
+            Integer price,
+
+            @Schema(description = "카테고리", example = "과일")
+            String category,
+
+            @Schema(description = "썸네일 URL", example = "https://example.com/thumb/1.jpg")
+            String thumbnailUrl
+    ) {
+    }
+
+    @Schema(description = "상품 목록 조회 응답 DTO (페이징 포함)")
+    public record ProductListResDTO(
+            @Schema(description = "전체 상품 개수", example = "50")
+            Long totalElements,
+
+            @Schema(description = "전체 페이지 수", example = "5")
+            Integer totalPages,
+
+            @Schema(description = "현재 페이지 번호 (0부터 시작)", example = "0")
+            Integer currentPage,
+
+            @Schema(description = "페이지당 개수", example = "10")
+            Integer size,
+
+            @Schema(description = "마지막 페이지 여부", example = "false")
+            Boolean isLast,
+
+            @Schema(description = "상품 목록")
+            List<ProductItemDTO> productList
+    ) {
+    }
+
+    @Schema(description = "상품 상세 조회 응답 DTO")
+    public record ProductDetailResDTO(
+            @Schema(description = "상품 ID", example = "1")
+            Long productId,
+
+            @Schema(description = "상품명", example = "사과")
+            String name,
+
+            @Schema(description = "가격", example = "3000")
+            Integer price,
+
+            @Schema(description = "카테고리", example = "과일")
+            String category,
+
+            @Schema(description = "상품 설명", example = "신선한 사과입니다.")
+            String description,
+
+            @Schema(description = "썸네일 URL", example = "https://example.com/thumb/1.jpg")
+            String thumbnailUrl,
+
+            @Schema(description = "등록 일시", example = "2026-04-29T09:00:00")
+            LocalDateTime createdAt
+    ) {
+    }
+
+    @Schema(description = "상품 추가 응답 DTO")
+    public record CreateProductResDTO(
+            @Schema(description = "상품 ID", example = "51")
+            Long productId,
+
+            @Schema(description = "상품명", example = "바나나")
+            String name,
+
+            @Schema(description = "가격", example = "2000")
+            Integer price,
+
+            @Schema(description = "등록 일시", example = "2026-04-29T11:00:00")
+            LocalDateTime createdAt
+    ) {
+    }
+
+    @Schema(description = "상품 삭제 응답 DTO")
+    public record DeleteProductResDTO(
+            @Schema(description = "상품 ID", example = "51")
+            Long productId,
+
+            @Schema(description = "삭제 일시", example = "2026-04-29T11:30:00")
+            LocalDateTime deletedAt
+    ) {
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/project/likelion14thbe/domain/product/repository/ProductRepository.java
@@ -1,9 +1,4 @@
 package com.project.likelion14thbe.domain.product.repository;
 
-import com.project.likelion14thbe.domain.product.entity.Product;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface ProductRepository extends JpaRepository<Product, Long> {
+public interface ProductRepository {
 }

--- a/src/main/java/com/project/likelion14thbe/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/controller/ReviewController.java
@@ -1,7 +1,181 @@
 package com.project.likelion14thbe.domain.review.controller;
 
+import com.project.likelion14thbe.domain.review.dto.request.ReviewReqDTO;
+import com.project.likelion14thbe.domain.review.dto.response.ReviewResDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Review", description = "리뷰 API — 생성, 단건/목록 조회, 수정, 삭제")
+@SecurityRequirement(name = "JWT TOKEN")
 @RestController
+@RequestMapping("/api/v1/products/{productId}/reviews")
 public class ReviewController {
+
+    @Operation(
+            summary = "리뷰 생성",
+            description = "특정 상품에 대해 새로운 리뷰를 생성한다. 동일 상품에 1인 1회 작성 제한."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "리뷰 생성 성공",
+                    content = @Content(schema = @Schema(implementation = ReviewResDTO.CreateReviewResDTO.class))),
+            @ApiResponse(responseCode = "400", description = "별점 범위 초과 또는 리뷰 내용 누락", content = @Content),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
+            @ApiResponse(responseCode = "404", description = "상품이 존재하지 않음", content = @Content),
+            @ApiResponse(responseCode = "409", description = "이미 해당 상품에 리뷰를 작성함", content = @Content)
+    })
+
+    @PostMapping
+    public ResponseEntity<ReviewResDTO.CreateReviewResDTO> createReview(
+            @Parameter(description = "상품 아이디", example = "5")
+            @PathVariable Long productId,
+            @Valid @RequestBody ReviewReqDTO.CreateReviewReqDTO request
+    ) {
+        ReviewResDTO.CreateReviewResDTO body = new ReviewResDTO.CreateReviewResDTO(
+                123L,
+                productId,
+                "bro",
+                request.rating(),
+                request.content(),
+                LocalDateTime.now()
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(body);
+    }
+
+    @Operation(
+            summary = "리뷰 단건 조회",
+            description = "특정 상품의 특정 리뷰 1건을 상세 조회한다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "리뷰 단건 조회 성공",
+                    content = @Content(schema = @Schema(implementation = ReviewResDTO.ReviewDetailResDTO.class))),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
+            @ApiResponse(responseCode = "404", description = "상품 또는 리뷰가 존재하지 않음", content = @Content)
+    })
+    @GetMapping("/{reviewId}")
+    public ResponseEntity<ReviewResDTO.ReviewDetailResDTO> getReview(
+            @Parameter(description = "상품 아이디", example = "5")
+            @PathVariable Long productId,
+            @Parameter(description = "리뷰 아이디", example = "1")
+            @PathVariable Long reviewId
+    ) {
+        ReviewResDTO.ReviewDetailResDTO body = new ReviewResDTO.ReviewDetailResDTO(
+                reviewId,
+                productId,
+                "bro",
+                4.5,
+                "nice!",
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+        return ResponseEntity.ok(body);
+    }
+
+    @Operation(
+            summary = "리뷰 목록 조회",
+            description = "특정 상품의 리뷰 목록을 페이징 조회한다. 정렬 기준은 latest / rating 지원."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "리뷰 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = ReviewResDTO.ReviewListResDTO.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 페이지 파라미터", content = @Content),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
+            @ApiResponse(responseCode = "404", description = "상품이 존재하지 않음", content = @Content)
+    })
+    @GetMapping
+    public ResponseEntity<ReviewResDTO.ReviewListResDTO> getReviewList(
+            @Parameter(description = "상품 아이디", example = "5")
+            @PathVariable Long productId,
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(defaultValue = "0") Integer page,
+            @Parameter(description = "페이지당 개수", example = "10")
+            @RequestParam(defaultValue = "10") Integer size,
+            @Parameter(description = "정렬 기준 (latest | rating)", example = "latest",
+                    schema = @Schema(allowableValues = {"latest", "rating"}))
+            @RequestParam(defaultValue = "latest") String sort
+    ) {
+        List<ReviewResDTO.ReviewItemDTO> reviewList = List.of(
+                new ReviewResDTO.ReviewItemDTO(1L, "bro", 4.5, "nice!", LocalDateTime.now()),
+                new ReviewResDTO.ReviewItemDTO(2L, "bro", 5.0, "이 제품 정말 좋아요", LocalDateTime.now())
+        );
+        ReviewResDTO.ReviewListResDTO body = new ReviewResDTO.ReviewListResDTO(
+                productId, 123L, 13, page, size, false, reviewList
+        );
+        return ResponseEntity.ok(body);
+    }
+
+    @Operation(
+            summary = "리뷰 수정",
+            description = "본인이 작성한 리뷰의 별점 또는 내용을 부분 수정한다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "리뷰 수정 성공",
+                    content = @Content(schema = @Schema(implementation = ReviewResDTO.UpdateReviewResDTO.class))),
+            @ApiResponse(responseCode = "400", description = "별점 범위 초과", content = @Content),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
+            @ApiResponse(responseCode = "403", description = "본인이 작성한 리뷰가 아님", content = @Content),
+            @ApiResponse(responseCode = "404", description = "리뷰가 존재하지 않음", content = @Content)
+    })
+    @PatchMapping("/{reviewId}")
+    public ResponseEntity<ReviewResDTO.UpdateReviewResDTO> updateReview(
+            @Parameter(description = "상품 아이디", example = "5")
+            @PathVariable Long productId,
+            @Parameter(description = "리뷰 아이디", example = "123")
+            @PathVariable Long reviewId,
+            @Valid @RequestBody ReviewReqDTO.UpdateReviewReqDTO request
+    ) {
+        ReviewResDTO.UpdateReviewResDTO body = new ReviewResDTO.UpdateReviewResDTO(
+                reviewId,
+                "bro",
+                request.rating() != null ? request.rating() : 5.0,
+                request.content() != null ? request.content() : "다시 먹어봤는데 더 맛있네요!",
+                LocalDateTime.now()
+        );
+        return ResponseEntity.ok(body);
+    }
+
+    @Operation(
+            summary = "리뷰 삭제",
+            description = "본인이 작성한 리뷰를 삭제한다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "리뷰 삭제 성공",
+                    content = @Content(schema = @Schema(implementation = ReviewResDTO.DeleteReviewResDTO.class))),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
+            @ApiResponse(responseCode = "403", description = "본인이 작성한 리뷰가 아님", content = @Content),
+            @ApiResponse(responseCode = "404", description = "리뷰가 존재하지 않음", content = @Content)
+    })
+    @DeleteMapping("/{reviewId}")
+    public ResponseEntity<ReviewResDTO.DeleteReviewResDTO> deleteReview(
+            @Parameter(description = "상품 아이디", example = "5")
+            @PathVariable Long productId,
+            @Parameter(description = "리뷰 아이디", example = "123")
+            @PathVariable Long reviewId
+    ) {
+        ReviewResDTO.DeleteReviewResDTO body = new ReviewResDTO.DeleteReviewResDTO(
+                reviewId,
+                LocalDateTime.now()
+        );
+        return ResponseEntity.ok(body);
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/controller/ReviewController.java
@@ -105,4 +105,22 @@ public class ReviewController implements ReviewDocs {
         );
         return ResponseEntity.ok(body);
     }
+
+    @Override
+    @GetMapping("/members/me/reviews")
+    public ResponseEntity<ReviewResDTO.MyReviewListResDTO> getMyReviews(
+            @RequestParam(defaultValue = "0") Integer page,
+            @RequestParam(defaultValue = "10") Integer size
+    ) {
+        List<ReviewResDTO.MyReviewItemDTO> reviewList = List.of(
+                new ReviewResDTO.MyReviewItemDTO(
+                        1L, 5L, "사과", 4.5, "nice!",
+                        LocalDateTime.now(), LocalDateTime.now()
+                )
+        );
+        ReviewResDTO.MyReviewListResDTO body = new ReviewResDTO.MyReviewListResDTO(
+                7L, 1, page, size, true, reviewList
+        );
+        return ResponseEntity.ok(body);
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/controller/ReviewController.java
@@ -1,15 +1,8 @@
 package com.project.likelion14thbe.domain.review.controller;
 
+import com.project.likelion14thbe.domain.review.controller.docs.ReviewDocs;
 import com.project.likelion14thbe.domain.review.dto.request.ReviewReqDTO;
 import com.project.likelion14thbe.domain.review.dto.response.ReviewResDTO;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,28 +19,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Review", description = "리뷰 API — 생성, 단건/목록 조회, 수정, 삭제")
-@SecurityRequirement(name = "JWT TOKEN")
 @RestController
-@RequestMapping("/api/v1/products/{productId}/reviews")
-public class ReviewController {
+@RequestMapping("/api/v1")
+public class ReviewController implements ReviewDocs {
 
-    @Operation(
-            summary = "리뷰 생성",
-            description = "특정 상품에 대해 새로운 리뷰를 생성한다. 동일 상품에 1인 1회 작성 제한."
-    )
-    @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "리뷰 생성 성공",
-                    content = @Content(schema = @Schema(implementation = ReviewResDTO.CreateReviewResDTO.class))),
-            @ApiResponse(responseCode = "400", description = "별점 범위 초과 또는 리뷰 내용 누락", content = @Content),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
-            @ApiResponse(responseCode = "404", description = "상품이 존재하지 않음", content = @Content),
-            @ApiResponse(responseCode = "409", description = "이미 해당 상품에 리뷰를 작성함", content = @Content)
-    })
-
-    @PostMapping
+    @Override
+    @PostMapping("/products/{productId}/reviews")
     public ResponseEntity<ReviewResDTO.CreateReviewResDTO> createReview(
-            @Parameter(description = "상품 아이디", example = "5")
             @PathVariable Long productId,
             @Valid @RequestBody ReviewReqDTO.CreateReviewReqDTO request
     ) {
@@ -62,21 +40,10 @@ public class ReviewController {
         return ResponseEntity.status(HttpStatus.CREATED).body(body);
     }
 
-    @Operation(
-            summary = "리뷰 단건 조회",
-            description = "특정 상품의 특정 리뷰 1건을 상세 조회한다."
-    )
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "리뷰 단건 조회 성공",
-                    content = @Content(schema = @Schema(implementation = ReviewResDTO.ReviewDetailResDTO.class))),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
-            @ApiResponse(responseCode = "404", description = "상품 또는 리뷰가 존재하지 않음", content = @Content)
-    })
-    @GetMapping("/{reviewId}")
+    @Override
+    @GetMapping("/products/{productId}/reviews/{reviewId}")
     public ResponseEntity<ReviewResDTO.ReviewDetailResDTO> getReview(
-            @Parameter(description = "상품 아이디", example = "5")
             @PathVariable Long productId,
-            @Parameter(description = "리뷰 아이디", example = "1")
             @PathVariable Long reviewId
     ) {
         ReviewResDTO.ReviewDetailResDTO body = new ReviewResDTO.ReviewDetailResDTO(
@@ -91,27 +58,12 @@ public class ReviewController {
         return ResponseEntity.ok(body);
     }
 
-    @Operation(
-            summary = "리뷰 목록 조회",
-            description = "특정 상품의 리뷰 목록을 페이징 조회한다. 정렬 기준은 latest / rating 지원."
-    )
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "리뷰 목록 조회 성공",
-                    content = @Content(schema = @Schema(implementation = ReviewResDTO.ReviewListResDTO.class))),
-            @ApiResponse(responseCode = "400", description = "잘못된 페이지 파라미터", content = @Content),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
-            @ApiResponse(responseCode = "404", description = "상품이 존재하지 않음", content = @Content)
-    })
-    @GetMapping
+    @Override
+    @GetMapping("/products/{productId}/reviews")
     public ResponseEntity<ReviewResDTO.ReviewListResDTO> getReviewList(
-            @Parameter(description = "상품 아이디", example = "5")
             @PathVariable Long productId,
-            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
             @RequestParam(defaultValue = "0") Integer page,
-            @Parameter(description = "페이지당 개수", example = "10")
             @RequestParam(defaultValue = "10") Integer size,
-            @Parameter(description = "정렬 기준 (latest | rating)", example = "latest",
-                    schema = @Schema(allowableValues = {"latest", "rating"}))
             @RequestParam(defaultValue = "latest") String sort
     ) {
         List<ReviewResDTO.ReviewItemDTO> reviewList = List.of(
@@ -124,23 +76,10 @@ public class ReviewController {
         return ResponseEntity.ok(body);
     }
 
-    @Operation(
-            summary = "리뷰 수정",
-            description = "본인이 작성한 리뷰의 별점 또는 내용을 부분 수정한다."
-    )
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "리뷰 수정 성공",
-                    content = @Content(schema = @Schema(implementation = ReviewResDTO.UpdateReviewResDTO.class))),
-            @ApiResponse(responseCode = "400", description = "별점 범위 초과", content = @Content),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
-            @ApiResponse(responseCode = "403", description = "본인이 작성한 리뷰가 아님", content = @Content),
-            @ApiResponse(responseCode = "404", description = "리뷰가 존재하지 않음", content = @Content)
-    })
-    @PatchMapping("/{reviewId}")
+    @Override
+    @PatchMapping("/products/{productId}/reviews/{reviewId}")
     public ResponseEntity<ReviewResDTO.UpdateReviewResDTO> updateReview(
-            @Parameter(description = "상품 아이디", example = "5")
             @PathVariable Long productId,
-            @Parameter(description = "리뷰 아이디", example = "123")
             @PathVariable Long reviewId,
             @Valid @RequestBody ReviewReqDTO.UpdateReviewReqDTO request
     ) {
@@ -154,22 +93,10 @@ public class ReviewController {
         return ResponseEntity.ok(body);
     }
 
-    @Operation(
-            summary = "리뷰 삭제",
-            description = "본인이 작성한 리뷰를 삭제한다."
-    )
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "리뷰 삭제 성공",
-                    content = @Content(schema = @Schema(implementation = ReviewResDTO.DeleteReviewResDTO.class))),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
-            @ApiResponse(responseCode = "403", description = "본인이 작성한 리뷰가 아님", content = @Content),
-            @ApiResponse(responseCode = "404", description = "리뷰가 존재하지 않음", content = @Content)
-    })
-    @DeleteMapping("/{reviewId}")
+    @Override
+    @DeleteMapping("/products/{productId}/reviews/{reviewId}")
     public ResponseEntity<ReviewResDTO.DeleteReviewResDTO> deleteReview(
-            @Parameter(description = "상품 아이디", example = "5")
             @PathVariable Long productId,
-            @Parameter(description = "리뷰 아이디", example = "123")
             @PathVariable Long reviewId
     ) {
         ReviewResDTO.DeleteReviewResDTO body = new ReviewResDTO.DeleteReviewResDTO(

--- a/src/main/java/com/project/likelion14thbe/domain/review/controller/docs/ReviewDocs.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/controller/docs/ReviewDocs.java
@@ -100,4 +100,19 @@ public interface ReviewDocs {
             @Parameter(description = "상품 아이디", example = "5") Long productId,
             @Parameter(description = "리뷰 아이디", example = "123") Long reviewId
     );
+
+    @Operation(
+            summary = "내 리뷰 조회",
+            description = "현재 로그인한 회원이 작성한 모든 리뷰를 페이징 조회한다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "내 리뷰 조회 성공",
+                    content = @Content(schema = @Schema(implementation = ReviewResDTO.MyReviewListResDTO.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 페이지 파라미터", content = @Content),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content)
+    })
+    ResponseEntity<ReviewResDTO.MyReviewListResDTO> getMyReviews(
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") Integer page,
+            @Parameter(description = "페이지당 개수", example = "10") Integer size
+    );
 }

--- a/src/main/java/com/project/likelion14thbe/domain/review/controller/docs/ReviewDocs.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/controller/docs/ReviewDocs.java
@@ -1,0 +1,103 @@
+package com.project.likelion14thbe.domain.review.controller.docs;
+
+import com.project.likelion14thbe.domain.review.dto.request.ReviewReqDTO;
+import com.project.likelion14thbe.domain.review.dto.response.ReviewResDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Review", description = "리뷰 API — 생성, 단건/목록 조회, 수정, 삭제")
+@SecurityRequirement(name = "JWT TOKEN")
+public interface ReviewDocs {
+
+    @Operation(
+            summary = "리뷰 생성",
+            description = "특정 상품에 대해 새로운 리뷰를 생성한다. 동일 상품에 1인 1회 작성 제한."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "리뷰 생성 성공",
+                    content = @Content(schema = @Schema(implementation = ReviewResDTO.CreateReviewResDTO.class))),
+            @ApiResponse(responseCode = "400", description = "별점 범위 초과 또는 리뷰 내용 누락", content = @Content),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
+            @ApiResponse(responseCode = "404", description = "상품이 존재하지 않음", content = @Content),
+            @ApiResponse(responseCode = "409", description = "이미 해당 상품에 리뷰를 작성함", content = @Content)
+    })
+    ResponseEntity<ReviewResDTO.CreateReviewResDTO> createReview(
+            @Parameter(description = "상품 아이디", example = "5") Long productId,
+            ReviewReqDTO.CreateReviewReqDTO request
+    );
+
+    @Operation(
+            summary = "리뷰 단건 조회",
+            description = "특정 상품의 특정 리뷰 1건을 상세 조회한다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "리뷰 단건 조회 성공",
+                    content = @Content(schema = @Schema(implementation = ReviewResDTO.ReviewDetailResDTO.class))),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
+            @ApiResponse(responseCode = "404", description = "상품 또는 리뷰가 존재하지 않음", content = @Content)
+    })
+    ResponseEntity<ReviewResDTO.ReviewDetailResDTO> getReview(
+            @Parameter(description = "상품 아이디", example = "5") Long productId,
+            @Parameter(description = "리뷰 아이디", example = "1") Long reviewId
+    );
+
+    @Operation(
+            summary = "리뷰 목록 조회",
+            description = "특정 상품의 리뷰 목록을 페이징 조회한다. 정렬 기준은 latest / rating 지원."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "리뷰 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = ReviewResDTO.ReviewListResDTO.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 페이지 파라미터", content = @Content),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
+            @ApiResponse(responseCode = "404", description = "상품이 존재하지 않음", content = @Content)
+    })
+    ResponseEntity<ReviewResDTO.ReviewListResDTO> getReviewList(
+            @Parameter(description = "상품 아이디", example = "5") Long productId,
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") Integer page,
+            @Parameter(description = "페이지당 개수", example = "10") Integer size,
+            @Parameter(description = "정렬 기준 (latest | rating)", example = "latest",
+                    schema = @Schema(allowableValues = {"latest", "rating"})) String sort
+    );
+
+    @Operation(
+            summary = "리뷰 수정",
+            description = "본인이 작성한 리뷰의 별점 또는 내용을 부분 수정한다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "리뷰 수정 성공",
+                    content = @Content(schema = @Schema(implementation = ReviewResDTO.UpdateReviewResDTO.class))),
+            @ApiResponse(responseCode = "400", description = "별점 범위 초과", content = @Content),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
+            @ApiResponse(responseCode = "403", description = "본인이 작성한 리뷰가 아님", content = @Content),
+            @ApiResponse(responseCode = "404", description = "리뷰가 존재하지 않음", content = @Content)
+    })
+    ResponseEntity<ReviewResDTO.UpdateReviewResDTO> updateReview(
+            @Parameter(description = "상품 아이디", example = "5") Long productId,
+            @Parameter(description = "리뷰 아이디", example = "123") Long reviewId,
+            ReviewReqDTO.UpdateReviewReqDTO request
+    );
+
+    @Operation(
+            summary = "리뷰 삭제",
+            description = "본인이 작성한 리뷰를 삭제한다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "리뷰 삭제 성공",
+                    content = @Content(schema = @Schema(implementation = ReviewResDTO.DeleteReviewResDTO.class))),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
+            @ApiResponse(responseCode = "403", description = "본인이 작성한 리뷰가 아님", content = @Content),
+            @ApiResponse(responseCode = "404", description = "리뷰가 존재하지 않음", content = @Content)
+    })
+    ResponseEntity<ReviewResDTO.DeleteReviewResDTO> deleteReview(
+            @Parameter(description = "상품 아이디", example = "5") Long productId,
+            @Parameter(description = "리뷰 아이디", example = "123") Long reviewId
+    );
+}

--- a/src/main/java/com/project/likelion14thbe/domain/review/dto/request/ReviewReqDTO.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/dto/request/ReviewReqDTO.java
@@ -1,4 +1,36 @@
 package com.project.likelion14thbe.domain.review.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public class ReviewReqDTO {
+
+    @Schema(description = "리뷰 생성 요청 DTO")
+    public record CreateReviewReqDTO(
+            @Schema(description = "별점 (0.5 이상 5.0 이하)", example = "4.5")
+            @NotNull(message = "별점은 필수입니다.")
+            @DecimalMin(value = "0.5", message = "별점은 0.5 이상이어야 합니다.")
+            @DecimalMax(value = "5.0", message = "별점은 5.0 이하여야 합니다.")
+            Double rating,
+
+            @Schema(description = "리뷰 내용", example = "이 제품 정말 좋아요")
+            @NotBlank(message = "리뷰 내용은 필수입니다.")
+            String content
+    ) {
+    }
+
+    @Schema(description = "리뷰 수정 요청 DTO (부분 수정 — 필드 선택)")
+    public record UpdateReviewReqDTO(
+            @Schema(description = "별점 (0.5 이상 5.0 이하, 선택)", example = "5.0")
+            @DecimalMin(value = "0.5", message = "별점은 0.5 이상이어야 합니다.")
+            @DecimalMax(value = "5.0", message = "별점은 5.0 이하여야 합니다.")
+            Double rating,
+
+            @Schema(description = "리뷰 내용 (선택)", example = "다시 먹어봤는데 더 맛있네요!")
+            String content
+    ) {
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/review/dto/response/ReviewResDTO.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/dto/response/ReviewResDTO.java
@@ -1,4 +1,129 @@
 package com.project.likelion14thbe.domain.review.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
 public class ReviewResDTO {
+
+    @Schema(description = "리뷰 생성 응답 DTO")
+    public record CreateReviewResDTO(
+            @Schema(description = "리뷰 ID", example = "123")
+            Long reviewId,
+
+            @Schema(description = "상품 ID", example = "5")
+            Long productId,
+
+            @Schema(description = "작성자 닉네임", example = "bro")
+            String writerNickname,
+
+            @Schema(description = "별점", example = "4.5")
+            Double rating,
+
+            @Schema(description = "리뷰 내용", example = "이 제품 정말 좋아요")
+            String content,
+
+            @Schema(description = "생성 일시", example = "2026-04-09T13:20:00")
+            LocalDateTime createdAt
+    ) {
+    }
+
+    @Schema(description = "리뷰 단건 조회 응답 DTO")
+    public record ReviewDetailResDTO(
+            @Schema(description = "리뷰 ID", example = "1")
+            Long reviewId,
+
+            @Schema(description = "상품 ID", example = "5")
+            Long productId,
+
+            @Schema(description = "작성자 닉네임", example = "bro")
+            String writerNickname,
+
+            @Schema(description = "별점", example = "4.5")
+            Double rating,
+
+            @Schema(description = "리뷰 내용", example = "nice!")
+            String content,
+
+            @Schema(description = "생성 일시", example = "2026-04-09T13:15:00")
+            LocalDateTime createdAt,
+
+            @Schema(description = "수정 일시", example = "2026-04-09T13:15:00")
+            LocalDateTime updatedAt
+    ) {
+    }
+
+    @Schema(description = "리뷰 목록 조회 — 개별 리뷰 아이템")
+    public record ReviewItemDTO(
+            @Schema(description = "리뷰 ID", example = "1")
+            Long reviewId,
+
+            @Schema(description = "작성자 닉네임", example = "bro")
+            String writerNickname,
+
+            @Schema(description = "별점", example = "4.5")
+            Double rating,
+
+            @Schema(description = "리뷰 내용", example = "nice!")
+            String content,
+
+            @Schema(description = "생성 일시", example = "2026-04-09T13:15:00")
+            LocalDateTime createdAt
+    ) {
+    }
+
+    @Schema(description = "리뷰 목록 조회 응답 DTO (페이징 포함)")
+    public record ReviewListResDTO(
+            @Schema(description = "상품 ID", example = "5")
+            Long productId,
+
+            @Schema(description = "전체 리뷰 개수", example = "123")
+            Long totalElements,
+
+            @Schema(description = "전체 페이지 수", example = "13")
+            Integer totalPages,
+
+            @Schema(description = "현재 페이지 번호 (0부터 시작)", example = "0")
+            Integer currentPage,
+
+            @Schema(description = "페이지당 개수", example = "10")
+            Integer size,
+
+            @Schema(description = "마지막 페이지 여부", example = "false")
+            Boolean isLast,
+
+            @Schema(description = "리뷰 목록")
+            List<ReviewItemDTO> reviewList
+    ) {
+    }
+
+    @Schema(description = "리뷰 수정 응답 DTO")
+    public record UpdateReviewResDTO(
+            @Schema(description = "리뷰 ID", example = "123")
+            Long reviewId,
+
+            @Schema(description = "작성자 닉네임", example = "bro")
+            String writerNickname,
+
+            @Schema(description = "별점", example = "5.0")
+            Double rating,
+
+            @Schema(description = "리뷰 내용", example = "다시 먹어봤는데 더 맛있네요!")
+            String content,
+
+            @Schema(description = "수정 일시", example = "2026-04-09T13:30:00")
+            LocalDateTime updatedAt
+    ) {
+    }
+
+    @Schema(description = "리뷰 삭제 응답 DTO")
+    public record DeleteReviewResDTO(
+            @Schema(description = "리뷰 ID", example = "123")
+            Long reviewId,
+
+            @Schema(description = "삭제 일시", example = "2026-04-09T13:40:00")
+            LocalDateTime deletedAt
+    ) {
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/review/dto/response/ReviewResDTO.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/dto/response/ReviewResDTO.java
@@ -126,4 +126,51 @@ public class ReviewResDTO {
             LocalDateTime deletedAt
     ) {
     }
+
+    @Schema(description = "내 리뷰 조회 — 개별 리뷰 아이템")
+    public record MyReviewItemDTO(
+            @Schema(description = "리뷰 ID", example = "1")
+            Long reviewId,
+
+            @Schema(description = "상품 ID", example = "5")
+            Long productId,
+
+            @Schema(description = "상품명", example = "사과")
+            String productName,
+
+            @Schema(description = "별점", example = "4.5")
+            Double rating,
+
+            @Schema(description = "리뷰 내용", example = "nice!")
+            String content,
+
+            @Schema(description = "생성 일시", example = "2026-04-29T13:15:00")
+            LocalDateTime createdAt,
+
+            @Schema(description = "수정 일시", example = "2026-04-29T13:15:00")
+            LocalDateTime updatedAt
+    ) {
+    }
+
+    @Schema(description = "내 리뷰 조회 응답 DTO (페이징 포함)")
+    public record MyReviewListResDTO(
+            @Schema(description = "전체 리뷰 개수", example = "7")
+            Long totalElements,
+
+            @Schema(description = "전체 페이지 수", example = "1")
+            Integer totalPages,
+
+            @Schema(description = "현재 페이지 번호 (0부터 시작)", example = "0")
+            Integer currentPage,
+
+            @Schema(description = "페이지당 개수", example = "10")
+            Integer size,
+
+            @Schema(description = "마지막 페이지 여부", example = "true")
+            Boolean isLast,
+
+            @Schema(description = "내가 작성한 리뷰 목록")
+            List<MyReviewItemDTO> reviewList
+    ) {
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/repository/ReviewRepository.java
@@ -1,9 +1,4 @@
 package com.project.likelion14thbe.domain.review.repository;
 
-import com.project.likelion14thbe.domain.review.entity.Review;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface ReviewRepository extends JpaRepository<Review, Long> {
+public interface ReviewRepository {
 }

--- a/src/main/java/com/project/likelion14thbe/global/config/SwaggerConfig.java
+++ b/src/main/java/com/project/likelion14thbe/global/config/SwaggerConfig.java
@@ -3,7 +3,6 @@ package com.project.likelion14thbe.global.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
@@ -11,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
-    // http://localhost:8080/swagger-ui/index.html#/
+    // http://localhost:8081/swagger-ui/index.html#/
 
     @Bean
     public OpenAPI LikeLionAPI() {
@@ -21,10 +20,8 @@ public class SwaggerConfig {
                 .version("1.0.0"); //버전
 
         String jwtSchemeName = "JWT TOKEN";
-        // API 요청헤더에 인증정보 포함
-        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
 
-        // SecuritySchemes 등록
+        // JWT Bearer 인증 스키마 등록 (전역 요구는 걸지 않음 — 인증 필요 API에 @SecurityRequirement 명시)
         Components components = new Components()
                 .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
                         .name(jwtSchemeName)
@@ -35,7 +32,6 @@ public class SwaggerConfig {
         return new OpenAPI()
                 .addServersItem(new Server().url("/"))
                 .info(info)
-                .addSecurityItem(securityRequirement)
                 .components(components);
     }
 }

--- a/src/main/java/com/project/likelion14thbe/global/config/SwaggerConfig.java
+++ b/src/main/java/com/project/likelion14thbe/global/config/SwaggerConfig.java
@@ -1,0 +1,41 @@
+package com.project.likelion14thbe.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    // http://localhost:8080/swagger-ui/index.html#/
+
+    @Bean
+    public OpenAPI LikeLionAPI() {
+        Info info = new Info()
+                .title("LikeLion API") // API 제목
+                .description("LikeLion API 명세서 입니다.") // 설명
+                .version("1.0.0"); //버전
+
+        String jwtSchemeName = "JWT TOKEN";
+        // API 요청헤더에 인증정보 포함
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+
+        // SecuritySchemes 등록
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP) // HTTP 방식
+                        .scheme("bearer")
+                        .bearerFormat("JWT"));
+
+        return new OpenAPI()
+                .addServersItem(new Server().url("/"))
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+}


### PR DESCRIPTION
# 🔗 Issue Number
- Closes #42

## 📌 작업 내용
- 3주차 과제: API 명세서 작성 + Swagger 코드 적용
- Member / Product / Order / Review 4개 도메인, 총 16개 API
- 팀장 Capstone-BackEnd 패턴 준용 — Swagger 어노테이션을 `XxxDocs` 인터페이스로 분리, Controller가 `implements`
- 응답 로직은 더미 데이터 (실제 서비스 로직/DB 연동/공통 응답 래퍼는 4주차 이후 범위)

## ✅ API 범위 (16개)

| Domain | Count | APIs |
| --- | ---: | --- |
| Member | 4 | 회원가입, 일반 로그인, 카카오 로그인, 비밀번호 수정 |
| Product | 4 | 목록 조회, 상세 조회, 상품 추가, 상품 삭제 |
| Order | 2 | 주문 생성, 내 주문 목록 |
| Review | 6 | 작성, 단건 조회, 목록 조회, 수정, 삭제, 내 리뷰 조회 |

URL 패턴:
- `/api/v1` prefix 통일
- "내 ~" 자원은 `/members/me/{resource}` (Microsoft Graph 패턴)
- 인증 필요 API에만 `@SecurityRequirement(name = \"JWT TOKEN\")` 명시 (전역 잠금 X)

## 🧭 컨벤션 반영
- Swagger 어노테이션: `domain/{domain}/controller/docs/XxxDocs.java`
- Controller: `implements XxxDocs`
- DTO: request/response 패키지 분리, record + nested 구조 + `@Schema` + Validation(`@NotBlank`, `@Email`, `@Size`, `@Min`, `@DecimalMin`)
- 커밋: 한 파일 수정당 한 커밋 원칙 (신규 17커밋)
- Gitmoji + 태그 (`✨feat:`, `♻️refactor:`)

## 📝 변경 파일 요약
- `global/config/SwaggerConfig.java` — 전역 인증 요구 제거 (스키마 등록만 유지)
- `domain/review/controller/docs/ReviewDocs.java` (신규)
- `domain/review/controller/ReviewController.java` — Docs implements + class prefix `/api/v1`로 변경, 6번째 API 추가
- `domain/review/dto/response/ReviewResDTO.java` — MyReview record 2종 추가
- `domain/member/{controller, controller/docs, dto/request, dto/response}` — 4개 파일 작성
- `domain/product/{controller, controller/docs, dto/request, dto/response}` — 4개 파일 작성
- `domain/order/{controller, controller/docs, dto/request, dto/response}` — 4개 파일 작성

## 🧪 확인 사항
- [x] 애플리케이션 실행 확인 (포트 8081)
- [x] Swagger UI 접속 확인 (`http://localhost:8081/swagger-ui/index.html`)
- [x] 16개 API 노출 확인 (Member 4 / Product 4 / Order 2 / Review 6)
- [x] JWT 자물쇠가 인증 필요 API에만 표시되는지 확인 (회원가입/로그인/카카오/상품 목록·상세 → 자물쇠 X)
- [x] `/v3/api-docs` 응답에서 path count = 16 검증

## 📚 부속 산출물
- `week3/멋사_백엔드_3주차_과제_1-2.md` — RESTful URL 수정 + HTTP 메서드 멱등성 (과제 1)
- `week3/멋사_백엔드_3주차_과제_4_Swagger조사.md` — Swagger 조사 (과제 1에 통합)
- `week3/멋사_백엔드_3주차_API명세서_전체.md` — 16개 API 통합 명세 (3단 구조 + 실패 케이스)

## ⚠️ 의도된 차이 (4주차 이후 범위)
- 응답 래퍼: 명세는 `{isSuccess, code, message, result}` 4필드 표준이지만 본 PR은 raw DTO만 반환. `CustomResponse<T>` 도입은 4주차.
- 글로벌 예외 처리, 도메인별 ErrorCode enum, 실 서비스 로직, DB 연동, 인증/권한 검증은 본 PR 범위 외.
- `application.yml`은 `.gitignore` 대상 — 로컬에서 `server.port=8081` + springdoc 옵션으로 확인.