### PR TITLE
✨feat: 4주차 과제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 
 	// Spring Data JPA
-	implementation 'org.springframework.data:spring-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	// MySQL Driver
+	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	// Validation (Jakarta Bean Validation)
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/project/likelion14thbe/Likelion14thbeApplication.java
+++ b/src/main/java/com/project/likelion14thbe/Likelion14thbeApplication.java
@@ -2,7 +2,9 @@ package com.project.likelion14thbe;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class Likelion14thbeApplication {
 

--- a/src/main/java/com/project/likelion14thbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.project.likelion14thbe.domain.member.controller.docs.MemberDocs;
 import com.project.likelion14thbe.domain.member.dto.request.MemberReqDTO;
 import com.project.likelion14thbe.domain.member.dto.response.MemberResDTO;
 import com.project.likelion14thbe.domain.member.service.command.MemberCommandService;
+import com.project.likelion14thbe.domain.member.service.query.MemberQueryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -23,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController implements MemberDocs {
 
     private final MemberCommandService memberCommandService;
+    private final MemberQueryService memberQueryService;
 
     @Override
     @PostMapping("/members")
@@ -62,13 +65,9 @@ public class MemberController implements MemberDocs {
 
     @Override
     @GetMapping("/members/me")
-    public ResponseEntity<MemberResDTO.MyInfoResDTO> getMyInfo() {
-        MemberResDTO.MyInfoResDTO body = new MemberResDTO.MyInfoResDTO(
-                1L,
-                "user@example.com",
-                "홍길동",
-                LocalDateTime.now()
-        );
-        return ResponseEntity.ok(body);
+    public ResponseEntity<MemberResDTO.MyInfoResDTO> getMyInfo(
+            @RequestParam Long memberId
+    ) {
+        return ResponseEntity.ok(memberQueryService.getMyInfo(memberId));
     }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/controller/MemberController.java
@@ -41,14 +41,7 @@ public class MemberController implements MemberDocs {
     public ResponseEntity<MemberResDTO.LoginResDTO> login(
             @Valid @RequestBody MemberReqDTO.LoginReqDTO request
     ) {
-        MemberResDTO.LoginResDTO body = new MemberResDTO.LoginResDTO(
-                1L,
-                "홍길동",
-                "eyJhbGciOiJIUzI1NiJ9.dummy.access",
-                "eyJhbGciOiJIUzI1NiJ9.dummy.refresh",
-                3600L
-        );
-        return ResponseEntity.ok(body);
+        return ResponseEntity.ok(memberCommandService.login(request));
     }
 
     @Override

--- a/src/main/java/com/project/likelion14thbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/controller/MemberController.java
@@ -3,7 +3,9 @@ package com.project.likelion14thbe.domain.member.controller;
 import com.project.likelion14thbe.domain.member.controller.docs.MemberDocs;
 import com.project.likelion14thbe.domain.member.dto.request.MemberReqDTO;
 import com.project.likelion14thbe.domain.member.dto.response.MemberResDTO;
+import com.project.likelion14thbe.domain.member.service.command.MemberCommandService;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -17,19 +19,17 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1")
+@RequiredArgsConstructor
 public class MemberController implements MemberDocs {
+
+    private final MemberCommandService memberCommandService;
 
     @Override
     @PostMapping("/members")
     public ResponseEntity<MemberResDTO.SignUpResDTO> signUp(
             @Valid @RequestBody MemberReqDTO.SignUpReqDTO request
     ) {
-        MemberResDTO.SignUpResDTO body = new MemberResDTO.SignUpResDTO(
-                1L,
-                request.email(),
-                request.nickname(),
-                LocalDateTime.now()
-        );
+        MemberResDTO.SignUpResDTO body = memberCommandService.signUp(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(body);
     }
 
@@ -40,25 +40,10 @@ public class MemberController implements MemberDocs {
     ) {
         MemberResDTO.LoginResDTO body = new MemberResDTO.LoginResDTO(
                 1L,
-                "bro",
+                "홍길동",
                 "eyJhbGciOiJIUzI1NiJ9.dummy.access",
                 "eyJhbGciOiJIUzI1NiJ9.dummy.refresh",
                 3600L
-        );
-        return ResponseEntity.ok(body);
-    }
-
-    @Override
-    @PostMapping("/auth/kakao/login")
-    public ResponseEntity<MemberResDTO.KakaoLoginResDTO> kakaoLogin(
-            @Valid @RequestBody MemberReqDTO.KakaoLoginReqDTO request
-    ) {
-        MemberResDTO.KakaoLoginResDTO body = new MemberResDTO.KakaoLoginResDTO(
-                1L,
-                "bro",
-                "eyJhbGciOiJIUzI1NiJ9.dummy.access",
-                "eyJhbGciOiJIUzI1NiJ9.dummy.refresh",
-                false
         );
         return ResponseEntity.ok(body);
     }
@@ -81,7 +66,7 @@ public class MemberController implements MemberDocs {
         MemberResDTO.MyInfoResDTO body = new MemberResDTO.MyInfoResDTO(
                 1L,
                 "user@example.com",
-                "bro",
+                "홍길동",
                 LocalDateTime.now()
         );
         return ResponseEntity.ok(body);

--- a/src/main/java/com/project/likelion14thbe/domain/member/controller/docs/MemberDocs.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/controller/docs/MemberDocs.java
@@ -2,9 +2,11 @@ package com.project.likelion14thbe.domain.member.controller.docs;
 
 import com.project.likelion14thbe.domain.member.dto.request.MemberReqDTO;
 import com.project.likelion14thbe.domain.member.dto.response.MemberResDTO;
+import com.project.likelion14thbe.global.response.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -22,8 +24,24 @@ public interface MemberDocs {
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "회원가입 성공",
                     content = @Content(schema = @Schema(implementation = MemberResDTO.SignUpResDTO.class))),
-            @ApiResponse(responseCode = "400", description = "입력 형식 오류 (이메일/비밀번호/이름)", content = @Content),
-            @ApiResponse(responseCode = "409", description = "이미 가입된 이메일", content = @Content)
+            @ApiResponse(responseCode = "400", description = "입력 형식 오류 (필수 필드 누락 / 이메일 형식 / 비밀번호 길이)",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "400 Bad Request",
+                                      "message": "잘못된 요청입니다."
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "409", description = "이미 가입된 이메일",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "409 Conflict",
+                                      "message": "이미 가입된 이메일입니다."
+                                    }
+                                    """)))
     })
     ResponseEntity<MemberResDTO.SignUpResDTO> signUp(MemberReqDTO.SignUpReqDTO request);
 
@@ -34,8 +52,24 @@ public interface MemberDocs {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "로그인 성공",
                     content = @Content(schema = @Schema(implementation = MemberResDTO.LoginResDTO.class))),
-            @ApiResponse(responseCode = "401", description = "이메일 또는 비밀번호 불일치", content = @Content),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 회원", content = @Content)
+            @ApiResponse(responseCode = "401", description = "비밀번호 불일치",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "401 Unauthorized",
+                                      "message": "이메일 또는 비밀번호가 일치하지 않습니다."
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 회원",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "404 Not Found",
+                                      "message": "존재하지 않는 회원입니다."
+                                    }
+                                    """)))
     })
     ResponseEntity<MemberResDTO.LoginResDTO> login(MemberReqDTO.LoginReqDTO request);
 
@@ -47,8 +81,33 @@ public interface MemberDocs {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공",
                     content = @Content(schema = @Schema(implementation = MemberResDTO.UpdatePasswordResDTO.class))),
-            @ApiResponse(responseCode = "400", description = "현재 비밀번호 불일치 또는 새 비밀번호 형식 오류", content = @Content),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content)
+            @ApiResponse(responseCode = "400", description = "현재 비밀번호 불일치 또는 새 비밀번호 형식 오류",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "현재 비밀번호 불일치", value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "400 Bad Request",
+                                              "message": "현재 비밀번호가 일치하지 않습니다."
+                                            }
+                                            """),
+                                    @ExampleObject(name = "새 비밀번호 형식 오류", value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "400 Bad Request",
+                                              "message": "비밀번호는 8자 이상이어야 합니다."
+                                            }
+                                            """)
+                            })),
+            @ApiResponse(responseCode = "401", description = "토큰 만료/유효하지 않음",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "401 Unauthorized",
+                                      "message": "유효하지 않은 토큰입니다."
+                                    }
+                                    """)))
     })
     ResponseEntity<MemberResDTO.UpdatePasswordResDTO> updatePassword(MemberReqDTO.UpdatePasswordReqDTO request);
 
@@ -60,8 +119,24 @@ public interface MemberDocs {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "내 정보 조회 성공",
                     content = @Content(schema = @Schema(implementation = MemberResDTO.MyInfoResDTO.class))),
-            @ApiResponse(responseCode = "401", description = "인증 토큰 없음 또는 만료", content = @Content),
-            @ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음 (탈퇴 등)", content = @Content)
+            @ApiResponse(responseCode = "401", description = "인증 토큰 없음 또는 만료",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "401 Unauthorized",
+                                      "message": "로그인이 필요합니다."
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "404", description = "회원 미존재 (탈퇴 등)",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "404 Not Found",
+                                      "message": "회원을 찾을 수 없습니다."
+                                    }
+                                    """)))
     })
     ResponseEntity<MemberResDTO.MyInfoResDTO> getMyInfo(
             @Parameter(description = "조회 회원 ID (JWT 적용 전 임시)", example = "1") Long memberId

--- a/src/main/java/com/project/likelion14thbe/domain/member/controller/docs/MemberDocs.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/controller/docs/MemberDocs.java
@@ -29,7 +29,7 @@ public interface MemberDocs {
 
     @Operation(
             summary = "일반 로그인",
-            description = "이메일·비밀번호로 로그인 후 JWT Access/Refresh 토큰을 발급한다."
+            description = "이메일·비밀번호로 로그인 후 JWT Access/Refresh 토큰을 발급한다. (현재 토큰 3개 필드는 dummy 상수 — 실제 발급은 jjwt 도입 시 service 내부에서 교체 예정)"
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "로그인 성공",

--- a/src/main/java/com/project/likelion14thbe/domain/member/controller/docs/MemberDocs.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/controller/docs/MemberDocs.java
@@ -3,6 +3,7 @@ package com.project.likelion14thbe.domain.member.controller.docs;
 import com.project.likelion14thbe.domain.member.dto.request.MemberReqDTO;
 import com.project.likelion14thbe.domain.member.dto.response.MemberResDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -53,7 +54,7 @@ public interface MemberDocs {
 
     @Operation(
             summary = "내 정보 조회",
-            description = "현재 로그인한 회원의 정보를 조회한다."
+            description = "현재 로그인한 회원의 정보를 조회한다. (JWT 적용 전까지 memberId는 임시 query 파라미터)"
     )
     @SecurityRequirement(name = "JWT TOKEN")
     @ApiResponses({
@@ -62,5 +63,7 @@ public interface MemberDocs {
             @ApiResponse(responseCode = "401", description = "인증 토큰 없음 또는 만료", content = @Content),
             @ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음 (탈퇴 등)", content = @Content)
     })
-    ResponseEntity<MemberResDTO.MyInfoResDTO> getMyInfo();
+    ResponseEntity<MemberResDTO.MyInfoResDTO> getMyInfo(
+            @Parameter(description = "조회 회원 ID (JWT 적용 전 임시)", example = "1") Long memberId
+    );
 }

--- a/src/main/java/com/project/likelion14thbe/domain/member/controller/docs/MemberDocs.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/controller/docs/MemberDocs.java
@@ -11,18 +11,18 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 
-@Tag(name = "Member", description = "회원 API — 회원가입, 로그인(일반/카카오), 내 정보 조회, 비밀번호 수정")
+@Tag(name = "Member", description = "회원 API — 회원가입, 로그인, 내 정보 조회, 비밀번호 수정")
 public interface MemberDocs {
 
     @Operation(
             summary = "회원가입",
-            description = "이메일·비밀번호·닉네임으로 신규 회원을 등록한다. 이메일·닉네임 중복 시 409."
+            description = "이메일·비밀번호·이름으로 신규 회원을 등록한다. 이메일 중복 시 409."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "회원가입 성공",
                     content = @Content(schema = @Schema(implementation = MemberResDTO.SignUpResDTO.class))),
-            @ApiResponse(responseCode = "400", description = "입력 형식 오류 (이메일/비밀번호/닉네임)", content = @Content),
-            @ApiResponse(responseCode = "409", description = "이미 가입된 이메일 또는 닉네임", content = @Content)
+            @ApiResponse(responseCode = "400", description = "입력 형식 오류 (이메일/비밀번호/이름)", content = @Content),
+            @ApiResponse(responseCode = "409", description = "이미 가입된 이메일", content = @Content)
     })
     ResponseEntity<MemberResDTO.SignUpResDTO> signUp(MemberReqDTO.SignUpReqDTO request);
 
@@ -37,18 +37,6 @@ public interface MemberDocs {
             @ApiResponse(responseCode = "404", description = "존재하지 않는 회원", content = @Content)
     })
     ResponseEntity<MemberResDTO.LoginResDTO> login(MemberReqDTO.LoginReqDTO request);
-
-    @Operation(
-            summary = "카카오 로그인",
-            description = "프론트에서 받은 카카오 OAuth Access Token을 검증하고 자체 JWT 토큰을 발급한다. 첫 로그인 시 자동 회원가입."
-    )
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "카카오 로그인 성공",
-                    content = @Content(schema = @Schema(implementation = MemberResDTO.KakaoLoginResDTO.class))),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 카카오 토큰", content = @Content),
-            @ApiResponse(responseCode = "502", description = "카카오 인증 서버 통신 실패", content = @Content)
-    })
-    ResponseEntity<MemberResDTO.KakaoLoginResDTO> kakaoLogin(MemberReqDTO.KakaoLoginReqDTO request);
 
     @Operation(
             summary = "비밀번호 수정",

--- a/src/main/java/com/project/likelion14thbe/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/converter/MemberConverter.java
@@ -1,8 +1,37 @@
 package com.project.likelion14thbe.domain.member.converter;
 
+import com.project.likelion14thbe.domain.member.dto.request.MemberReqDTO;
+import com.project.likelion14thbe.domain.member.dto.response.MemberResDTO;
+import com.project.likelion14thbe.domain.member.entity.Member;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberConverter {
+
+    public static Member toMember(MemberReqDTO.SignUpReqDTO request) {
+        return Member.builder()
+                .email(request.email())
+                .password(request.password())
+                .name(request.name())
+                .build();
+    }
+
+    public static MemberResDTO.SignUpResDTO toSignUpResDTO(Member member) {
+        return new MemberResDTO.SignUpResDTO(
+                member.getId(),
+                member.getEmail(),
+                member.getName(),
+                member.getCreatedAt()
+        );
+    }
+
+    public static MemberResDTO.MyInfoResDTO toMyInfoResDTO(Member member) {
+        return new MemberResDTO.MyInfoResDTO(
+                member.getId(),
+                member.getEmail(),
+                member.getName(),
+                member.getCreatedAt()
+        );
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/converter/MemberConverter.java
@@ -34,4 +34,19 @@ public class MemberConverter {
                 member.getCreatedAt()
         );
     }
+
+    public static MemberResDTO.LoginResDTO toLoginResDTO(
+            Member member,
+            String accessToken,
+            String refreshToken,
+            Long expiresIn
+    ) {
+        return new MemberResDTO.LoginResDTO(
+                member.getId(),
+                member.getName(),
+                accessToken,
+                refreshToken,
+                expiresIn
+        );
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/member/dto/request/MemberReqDTO.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/dto/request/MemberReqDTO.java
@@ -17,10 +17,10 @@ public class MemberReqDTO {
             @NotBlank(message = "비밀번호는 필수입니다.")
             @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
             String password,
-            @Schema(description = "닉네임 (2~20자)", example = "bro")
-            @NotBlank(message = "닉네임은 필수입니다.")
-            @Size(min = 2, max = 20, message = "닉네임은 2자 이상 20자 이하여야 합니다.")
-            String nickname
+            @Schema(description = "이름 (2~50자)", example = "홍길동")
+            @NotBlank(message = "이름은 필수입니다.")
+            @Size(min = 2, max = 50, message = "이름은 2자 이상 50자 이하여야 합니다.")
+            String name
     ) {
     }
 
@@ -33,15 +33,6 @@ public class MemberReqDTO {
             @Schema(description = "비밀번호", example = "passw0rd!!")
             @NotBlank(message = "비밀번호는 필수입니다.")
             String password
-    ) {
-    }
-
-    @Schema(description = "카카오 로그인 요청 DTO")
-    public record KakaoLoginReqDTO(
-            @Schema(description = "카카오 OAuth Access Token (프론트에서 발급받아 전달)",
-                    example = "kakao_access_token_value")
-            @NotBlank(message = "카카오 액세스 토큰은 필수입니다.")
-            String accessToken
     ) {
     }
 

--- a/src/main/java/com/project/likelion14thbe/domain/member/dto/response/MemberResDTO.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/dto/response/MemberResDTO.java
@@ -12,8 +12,8 @@ public class MemberResDTO {
             Long memberId,
             @Schema(description = "이메일", example = "user@example.com")
             String email,
-            @Schema(description = "닉네임", example = "bro")
-            String nickname,
+            @Schema(description = "이름", example = "홍길동")
+            String name,
             @Schema(description = "가입 일시", example = "2026-04-29T10:00:00")
             LocalDateTime createdAt
     ) {
@@ -23,29 +23,14 @@ public class MemberResDTO {
     public record LoginResDTO(
             @Schema(description = "회원 ID", example = "1")
             Long memberId,
-            @Schema(description = "닉네임", example = "bro")
-            String nickname,
+            @Schema(description = "이름", example = "홍길동")
+            String name,
             @Schema(description = "JWT Access Token", example = "eyJhbGciOi...")
             String accessToken,
             @Schema(description = "JWT Refresh Token", example = "eyJhbGciOi...")
             String refreshToken,
             @Schema(description = "Access Token 만료 시간(초)", example = "3600")
             Long expiresIn
-    ) {
-    }
-
-    @Schema(description = "카카오 로그인 응답 DTO")
-    public record KakaoLoginResDTO(
-            @Schema(description = "회원 ID", example = "1")
-            Long memberId,
-            @Schema(description = "닉네임", example = "bro")
-            String nickname,
-            @Schema(description = "JWT Access Token", example = "eyJhbGciOi...")
-            String accessToken,
-            @Schema(description = "JWT Refresh Token", example = "eyJhbGciOi...")
-            String refreshToken,
-            @Schema(description = "신규 회원 여부 (카카오 첫 로그인 시 true)", example = "false")
-            Boolean isNewMember
     ) {
     }
 
@@ -64,8 +49,8 @@ public class MemberResDTO {
             Long memberId,
             @Schema(description = "이메일", example = "user@example.com")
             String email,
-            @Schema(description = "닉네임", example = "bro")
-            String nickname,
+            @Schema(description = "이름", example = "홍길동")
+            String name,
             @Schema(description = "가입 일시", example = "2026-04-29T10:00:00")
             LocalDateTime createdAt
     ) {

--- a/src/main/java/com/project/likelion14thbe/domain/member/entity/Member.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/entity/Member.java
@@ -1,5 +1,39 @@
 package com.project.likelion14thbe.domain.member.entity;
 
-//@Entity
-public class Member {
+import com.project.likelion14thbe.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "member")
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 50)
+    private String name;
+
+    @Column(name = "email", nullable = false, unique = true, length = 100)
+    private String email;
+
+    @Column(name = "password", nullable = false, length = 255)
+    private String password;
+
+    @Column(name = "profile_image", length = 500)
+    private String profileImage;
 }

--- a/src/main/java/com/project/likelion14thbe/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/repository/MemberRepository.java
@@ -1,4 +1,13 @@
 package com.project.likelion14thbe.domain.member.repository;
 
-public interface MemberRepository {
+import com.project.likelion14thbe.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/project/likelion14thbe/domain/member/service/command/MemberCommandService.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/service/command/MemberCommandService.java
@@ -6,4 +6,6 @@ import com.project.likelion14thbe.domain.member.dto.response.MemberResDTO;
 public interface MemberCommandService {
 
     MemberResDTO.SignUpResDTO signUp(MemberReqDTO.SignUpReqDTO request);
+
+    MemberResDTO.LoginResDTO login(MemberReqDTO.LoginReqDTO request);
 }

--- a/src/main/java/com/project/likelion14thbe/domain/member/service/command/MemberCommandService.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/service/command/MemberCommandService.java
@@ -1,4 +1,9 @@
 package com.project.likelion14thbe.domain.member.service.command;
 
+import com.project.likelion14thbe.domain.member.dto.request.MemberReqDTO;
+import com.project.likelion14thbe.domain.member.dto.response.MemberResDTO;
+
 public interface MemberCommandService {
+
+    MemberResDTO.SignUpResDTO signUp(MemberReqDTO.SignUpReqDTO request);
 }

--- a/src/main/java/com/project/likelion14thbe/domain/member/service/command/MemberCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/service/command/MemberCommandServiceImpl.java
@@ -34,7 +34,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         Member member = memberRepository.findByEmail(request.email())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."));
         if (!member.getPassword().equals(request.password())) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다.");
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 일치하지 않습니다.");
         }
         String accessToken = "eyJhbGciOiJIUzI1NiJ9.dummy.access";
         String refreshToken = "eyJhbGciOiJIUzI1NiJ9.dummy.refresh";

--- a/src/main/java/com/project/likelion14thbe/domain/member/service/command/MemberCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/service/command/MemberCommandServiceImpl.java
@@ -27,4 +27,18 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         Member saved = memberRepository.save(member);
         return MemberConverter.toSignUpResDTO(saved);
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public MemberResDTO.LoginResDTO login(MemberReqDTO.LoginReqDTO request) {
+        Member member = memberRepository.findByEmail(request.email())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."));
+        if (!member.getPassword().equals(request.password())) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다.");
+        }
+        String accessToken = "eyJhbGciOiJIUzI1NiJ9.dummy.access";
+        String refreshToken = "eyJhbGciOiJIUzI1NiJ9.dummy.refresh";
+        Long expiresIn = 3600L;
+        return MemberConverter.toLoginResDTO(member, accessToken, refreshToken, expiresIn);
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/member/service/command/MemberCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/service/command/MemberCommandServiceImpl.java
@@ -1,7 +1,30 @@
 package com.project.likelion14thbe.domain.member.service.command;
 
+import com.project.likelion14thbe.domain.member.converter.MemberConverter;
+import com.project.likelion14thbe.domain.member.dto.request.MemberReqDTO;
+import com.project.likelion14thbe.domain.member.dto.response.MemberResDTO;
+import com.project.likelion14thbe.domain.member.entity.Member;
+import com.project.likelion14thbe.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
+@RequiredArgsConstructor
+@Transactional
 public class MemberCommandServiceImpl implements MemberCommandService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public MemberResDTO.SignUpResDTO signUp(MemberReqDTO.SignUpReqDTO request) {
+        if (memberRepository.existsByEmail(request.email())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 가입된 이메일입니다.");
+        }
+        Member member = MemberConverter.toMember(request);
+        Member saved = memberRepository.save(member);
+        return MemberConverter.toSignUpResDTO(saved);
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/member/service/query/MemberQueryService.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/service/query/MemberQueryService.java
@@ -1,4 +1,8 @@
 package com.project.likelion14thbe.domain.member.service.query;
 
+import com.project.likelion14thbe.domain.member.dto.response.MemberResDTO;
+
 public interface MemberQueryService {
+
+    MemberResDTO.MyInfoResDTO getMyInfo(Long memberId);
 }

--- a/src/main/java/com/project/likelion14thbe/domain/member/service/query/MemberQueryServiceImpl.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/service/query/MemberQueryServiceImpl.java
@@ -1,7 +1,26 @@
 package com.project.likelion14thbe.domain.member.service.query;
 
+import com.project.likelion14thbe.domain.member.converter.MemberConverter;
+import com.project.likelion14thbe.domain.member.dto.response.MemberResDTO;
+import com.project.likelion14thbe.domain.member.entity.Member;
+import com.project.likelion14thbe.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MemberQueryServiceImpl implements MemberQueryService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public MemberResDTO.MyInfoResDTO getMyInfo(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."));
+        return MemberConverter.toMyInfoResDTO(member);
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/order/controller/OrderController.java
+++ b/src/main/java/com/project/likelion14thbe/domain/order/controller/OrderController.java
@@ -3,12 +3,13 @@ package com.project.likelion14thbe.domain.order.controller;
 import com.project.likelion14thbe.domain.order.controller.docs.OrderDocs;
 import com.project.likelion14thbe.domain.order.dto.request.OrderReqDTO;
 import com.project.likelion14thbe.domain.order.dto.response.OrderResDTO;
+import com.project.likelion14thbe.domain.order.service.command.OrderCommandService;
+import com.project.likelion14thbe.domain.order.service.query.OrderQueryService;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import java.time.LocalDateTime;
-import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,39 +19,29 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1")
+@RequiredArgsConstructor
 public class OrderController implements OrderDocs {
+
+    private final OrderCommandService orderCommandService;
+    private final OrderQueryService orderQueryService;
 
     @Override
     @PostMapping("/orders")
     public ResponseEntity<OrderResDTO.CreateOrderResDTO> createOrder(
+            @RequestParam Long memberId,
             @Valid @RequestBody OrderReqDTO.CreateOrderReqDTO request
     ) {
-        int totalPrice = request.quantity() * 3000;
-        OrderResDTO.CreateOrderResDTO body = new OrderResDTO.CreateOrderResDTO(
-                100L,
-                request.productId(),
-                request.quantity(),
-                totalPrice,
-                "PENDING",
-                LocalDateTime.now()
-        );
+        OrderResDTO.CreateOrderResDTO body = orderCommandService.createOrder(memberId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(body);
     }
 
     @Override
     @GetMapping("/members/me/orders")
     public ResponseEntity<OrderResDTO.MyOrderListResDTO> getMyOrders(
+            @RequestParam Long memberId,
             @RequestParam(defaultValue = "0") Integer page,
             @RequestParam(defaultValue = "10") Integer size
     ) {
-        List<OrderResDTO.MyOrderItemDTO> orderList = List.of(
-                new OrderResDTO.MyOrderItemDTO(
-                        100L, 5L, "사과", 2, 6000, "DELIVERED", LocalDateTime.now()
-                )
-        );
-        OrderResDTO.MyOrderListResDTO body = new OrderResDTO.MyOrderListResDTO(
-                12L, 2, page, size, false, orderList
-        );
-        return ResponseEntity.ok(body);
+        return ResponseEntity.ok(orderQueryService.getMyOrders(memberId, page, size));
     }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/order/controller/docs/OrderDocs.java
+++ b/src/main/java/com/project/likelion14thbe/domain/order/controller/docs/OrderDocs.java
@@ -18,30 +18,33 @@ public interface OrderDocs {
 
     @Operation(
             summary = "주문 생성",
-            description = "현재 로그인한 회원이 특정 상품을 주문한다."
+            description = "현재 로그인한 회원이 특정 상품을 주문한다. (JWT 적용 전까지 memberId는 임시 query 파라미터)"
     )
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "주문 생성 성공",
                     content = @Content(schema = @Schema(implementation = OrderResDTO.CreateOrderResDTO.class))),
             @ApiResponse(responseCode = "400", description = "잘못된 수량 또는 입력 형식 오류", content = @Content),
             @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
-            @ApiResponse(responseCode = "404", description = "상품이 존재하지 않음", content = @Content)
+            @ApiResponse(responseCode = "404", description = "회원 또는 상품이 존재하지 않음", content = @Content)
     })
     ResponseEntity<OrderResDTO.CreateOrderResDTO> createOrder(
+            @Parameter(description = "주문자 회원 ID (JWT 적용 전 임시)", example = "1") Long memberId,
             OrderReqDTO.CreateOrderReqDTO request
     );
 
     @Operation(
             summary = "내 주문 목록 조회",
-            description = "현재 로그인한 회원의 모든 주문을 페이징 조회한다."
+            description = "현재 로그인한 회원의 모든 주문을 페이징 조회한다. (JWT 적용 전까지 memberId는 임시 query 파라미터)"
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "내 주문 목록 조회 성공",
                     content = @Content(schema = @Schema(implementation = OrderResDTO.MyOrderListResDTO.class))),
             @ApiResponse(responseCode = "400", description = "잘못된 페이지 파라미터", content = @Content),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content)
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
+            @ApiResponse(responseCode = "404", description = "회원이 존재하지 않음", content = @Content)
     })
     ResponseEntity<OrderResDTO.MyOrderListResDTO> getMyOrders(
+            @Parameter(description = "조회 회원 ID (JWT 적용 전 임시)", example = "1") Long memberId,
             @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") Integer page,
             @Parameter(description = "페이지당 개수", example = "10") Integer size
     );

--- a/src/main/java/com/project/likelion14thbe/domain/order/controller/docs/OrderDocs.java
+++ b/src/main/java/com/project/likelion14thbe/domain/order/controller/docs/OrderDocs.java
@@ -2,9 +2,11 @@ package com.project.likelion14thbe.domain.order.controller.docs;
 
 import com.project.likelion14thbe.domain.order.dto.request.OrderReqDTO;
 import com.project.likelion14thbe.domain.order.dto.response.OrderResDTO;
+import com.project.likelion14thbe.global.response.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -23,9 +25,42 @@ public interface OrderDocs {
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "주문 생성 성공",
                     content = @Content(schema = @Schema(implementation = OrderResDTO.CreateOrderResDTO.class))),
-            @ApiResponse(responseCode = "400", description = "잘못된 수량 또는 입력 형식 오류", content = @Content),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
-            @ApiResponse(responseCode = "404", description = "회원 또는 상품이 존재하지 않음", content = @Content)
+            @ApiResponse(responseCode = "400", description = "잘못된 수량 또는 입력 형식 오류",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "400 Bad Request",
+                                      "message": "수량은 1 이상이어야 합니다."
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "401 Unauthorized",
+                                      "message": "유효하지 않은 토큰입니다."
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "404", description = "회원 또는 상품이 존재하지 않음",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "상품 미존재", value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "404 Not Found",
+                                              "message": "상품이 존재하지 않습니다."
+                                            }
+                                            """),
+                                    @ExampleObject(name = "회원 미존재", value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "404 Not Found",
+                                              "message": "회원을 찾을 수 없습니다."
+                                            }
+                                            """)
+                            }))
     })
     ResponseEntity<OrderResDTO.CreateOrderResDTO> createOrder(
             @Parameter(description = "주문자 회원 ID (JWT 적용 전 임시)", example = "1") Long memberId,
@@ -39,9 +74,33 @@ public interface OrderDocs {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "내 주문 목록 조회 성공",
                     content = @Content(schema = @Schema(implementation = OrderResDTO.MyOrderListResDTO.class))),
-            @ApiResponse(responseCode = "400", description = "잘못된 페이지 파라미터", content = @Content),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
-            @ApiResponse(responseCode = "404", description = "회원이 존재하지 않음", content = @Content)
+            @ApiResponse(responseCode = "400", description = "잘못된 페이지 파라미터",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "400 Bad Request",
+                                      "message": "잘못된 요청입니다."
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "401 Unauthorized",
+                                      "message": "유효하지 않은 토큰입니다."
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "404", description = "회원이 존재하지 않음",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "404 Not Found",
+                                      "message": "회원을 찾을 수 없습니다."
+                                    }
+                                    """)))
     })
     ResponseEntity<OrderResDTO.MyOrderListResDTO> getMyOrders(
             @Parameter(description = "조회 회원 ID (JWT 적용 전 임시)", example = "1") Long memberId,

--- a/src/main/java/com/project/likelion14thbe/domain/order/converter/OrderConverter.java
+++ b/src/main/java/com/project/likelion14thbe/domain/order/converter/OrderConverter.java
@@ -1,8 +1,70 @@
 package com.project.likelion14thbe.domain.order.converter;
 
+import com.project.likelion14thbe.domain.member.entity.Member;
+import com.project.likelion14thbe.domain.order.dto.request.OrderReqDTO;
+import com.project.likelion14thbe.domain.order.dto.response.OrderResDTO;
+import com.project.likelion14thbe.domain.order.entity.Order;
+import com.project.likelion14thbe.domain.order.entity.OrderStatus;
+import com.project.likelion14thbe.domain.product.entity.Product;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class OrderConverter {
+
+    public static Order toOrder(
+            Member member,
+            Product product,
+            OrderReqDTO.CreateOrderReqDTO request,
+            Integer totalPrice
+    ) {
+        return Order.builder()
+                .member(member)
+                .product(product)
+                .quantity(request.quantity())
+                .totalPrice(totalPrice)
+                .status(OrderStatus.PENDING)
+                .address(request.address())
+                .build();
+    }
+
+    public static OrderResDTO.CreateOrderResDTO toCreateOrderResDTO(Order order) {
+        return new OrderResDTO.CreateOrderResDTO(
+                order.getId(),
+                order.getProduct().getId(),
+                order.getQuantity(),
+                order.getTotalPrice(),
+                order.getStatus().name(),
+                order.getCreatedAt()
+        );
+    }
+
+    public static OrderResDTO.MyOrderItemDTO toMyOrderItemDTO(Order order) {
+        return new OrderResDTO.MyOrderItemDTO(
+                order.getId(),
+                order.getProduct().getId(),
+                order.getProduct().getName(),
+                order.getQuantity(),
+                order.getTotalPrice(),
+                order.getStatus().name(),
+                order.getCreatedAt()
+        );
+    }
+
+    public static OrderResDTO.MyOrderListResDTO toMyOrderListResDTO(Page<Order> page) {
+        List<OrderResDTO.MyOrderItemDTO> orderList = page.getContent().stream()
+                .map(OrderConverter::toMyOrderItemDTO)
+                .toList();
+        return new OrderResDTO.MyOrderListResDTO(
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.getNumber(),
+                page.getSize(),
+                page.isLast(),
+                orderList
+        );
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/order/entity/Order.java
+++ b/src/main/java/com/project/likelion14thbe/domain/order/entity/Order.java
@@ -1,5 +1,55 @@
 package com.project.likelion14thbe.domain.order.entity;
 
-//@Entity
-public class Order {
+import com.project.likelion14thbe.domain.member.entity.Member;
+import com.project.likelion14thbe.domain.product.entity.Product;
+import com.project.likelion14thbe.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "orders")
+public class Order extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
+
+    @Column(name = "total_price", nullable = false)
+    private Integer totalPrice;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private OrderStatus status;
+
+    @Column(name = "address", nullable = false, length = 500)
+    private String address;
 }

--- a/src/main/java/com/project/likelion14thbe/domain/order/entity/OrderStatus.java
+++ b/src/main/java/com/project/likelion14thbe/domain/order/entity/OrderStatus.java
@@ -1,0 +1,8 @@
+package com.project.likelion14thbe.domain.order.entity;
+
+public enum OrderStatus {
+    PENDING,
+    PAID,
+    DELIVERED,
+    CANCELLED
+}

--- a/src/main/java/com/project/likelion14thbe/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/project/likelion14thbe/domain/order/repository/OrderRepository.java
@@ -1,4 +1,11 @@
 package com.project.likelion14thbe.domain.order.repository;
 
-public interface OrderRepository {
+import com.project.likelion14thbe.domain.order.entity.Order;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    Page<Order> findAllByMember_IdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/project/likelion14thbe/domain/order/service/command/OrderCommandService.java
+++ b/src/main/java/com/project/likelion14thbe/domain/order/service/command/OrderCommandService.java
@@ -1,4 +1,9 @@
 package com.project.likelion14thbe.domain.order.service.command;
 
+import com.project.likelion14thbe.domain.order.dto.request.OrderReqDTO;
+import com.project.likelion14thbe.domain.order.dto.response.OrderResDTO;
+
 public interface OrderCommandService {
+
+    OrderResDTO.CreateOrderResDTO createOrder(Long memberId, OrderReqDTO.CreateOrderReqDTO request);
 }

--- a/src/main/java/com/project/likelion14thbe/domain/order/service/command/OrderCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion14thbe/domain/order/service/command/OrderCommandServiceImpl.java
@@ -1,7 +1,39 @@
 package com.project.likelion14thbe.domain.order.service.command;
 
+import com.project.likelion14thbe.domain.member.entity.Member;
+import com.project.likelion14thbe.domain.member.repository.MemberRepository;
+import com.project.likelion14thbe.domain.order.converter.OrderConverter;
+import com.project.likelion14thbe.domain.order.dto.request.OrderReqDTO;
+import com.project.likelion14thbe.domain.order.dto.response.OrderResDTO;
+import com.project.likelion14thbe.domain.order.entity.Order;
+import com.project.likelion14thbe.domain.order.repository.OrderRepository;
+import com.project.likelion14thbe.domain.product.entity.Product;
+import com.project.likelion14thbe.domain.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
+@RequiredArgsConstructor
+@Transactional
 public class OrderCommandServiceImpl implements OrderCommandService {
+
+    private final OrderRepository orderRepository;
+    private final MemberRepository memberRepository;
+    private final ProductRepository productRepository;
+
+    @Override
+    public OrderResDTO.CreateOrderResDTO createOrder(Long memberId, OrderReqDTO.CreateOrderReqDTO request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."));
+        Product product = productRepository.findById(request.productId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."));
+
+        Integer totalPrice = product.getPrice() * request.quantity();
+        Order order = OrderConverter.toOrder(member, product, request, totalPrice);
+        Order saved = orderRepository.save(order);
+        return OrderConverter.toCreateOrderResDTO(saved);
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/order/service/command/OrderCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion14thbe/domain/order/service/command/OrderCommandServiceImpl.java
@@ -29,7 +29,7 @@ public class OrderCommandServiceImpl implements OrderCommandService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."));
         Product product = productRepository.findById(request.productId())
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "상품이 존재하지 않습니다."));
 
         Integer totalPrice = product.getPrice() * request.quantity();
         Order order = OrderConverter.toOrder(member, product, request, totalPrice);

--- a/src/main/java/com/project/likelion14thbe/domain/order/service/query/OrderQueryService.java
+++ b/src/main/java/com/project/likelion14thbe/domain/order/service/query/OrderQueryService.java
@@ -1,4 +1,8 @@
 package com.project.likelion14thbe.domain.order.service.query;
 
+import com.project.likelion14thbe.domain.order.dto.response.OrderResDTO;
+
 public interface OrderQueryService {
+
+    OrderResDTO.MyOrderListResDTO getMyOrders(Long memberId, Integer page, Integer size);
 }

--- a/src/main/java/com/project/likelion14thbe/domain/order/service/query/OrderQueryServiceImpl.java
+++ b/src/main/java/com/project/likelion14thbe/domain/order/service/query/OrderQueryServiceImpl.java
@@ -1,7 +1,34 @@
 package com.project.likelion14thbe.domain.order.service.query;
 
+import com.project.likelion14thbe.domain.member.repository.MemberRepository;
+import com.project.likelion14thbe.domain.order.converter.OrderConverter;
+import com.project.likelion14thbe.domain.order.dto.response.OrderResDTO;
+import com.project.likelion14thbe.domain.order.entity.Order;
+import com.project.likelion14thbe.domain.order.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class OrderQueryServiceImpl implements OrderQueryService {
+
+    private final OrderRepository orderRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public OrderResDTO.MyOrderListResDTO getMyOrders(Long memberId, Integer page, Integer size) {
+        if (!memberRepository.existsById(memberId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다.");
+        }
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Order> orders = orderRepository.findAllByMember_IdOrderByCreatedAtDesc(memberId, pageable);
+        return OrderConverter.toMyOrderListResDTO(orders);
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/product/controller/ProductController.java
+++ b/src/main/java/com/project/likelion14thbe/domain/product/controller/ProductController.java
@@ -3,12 +3,14 @@ package com.project.likelion14thbe.domain.product.controller;
 import com.project.likelion14thbe.domain.product.controller.docs.ProductDocs;
 import com.project.likelion14thbe.domain.product.dto.request.ProductReqDTO;
 import com.project.likelion14thbe.domain.product.dto.response.ProductResDTO;
+import com.project.likelion14thbe.domain.product.service.command.ProductCommandService;
+import com.project.likelion14thbe.domain.product.service.query.ProductQueryService;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -20,7 +22,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/products")
+@RequiredArgsConstructor
 public class ProductController implements ProductDocs {
+
+    private final ProductCommandService productCommandService;
+    private final ProductQueryService productQueryService;
 
     @Override
     @GetMapping
@@ -30,18 +36,7 @@ public class ProductController implements ProductDocs {
             @RequestParam(defaultValue = "0") Integer page,
             @RequestParam(defaultValue = "10") Integer size
     ) {
-        List<ProductResDTO.ProductItemDTO> productList = List.of(
-                new ProductResDTO.ProductItemDTO(
-                        1L, "사과", 3000, "과일", "https://example.com/thumb/1.jpg"
-                ),
-                new ProductResDTO.ProductItemDTO(
-                        2L, "바나나", 2000, "과일", "https://example.com/thumb/2.jpg"
-                )
-        );
-        ProductResDTO.ProductListResDTO body = new ProductResDTO.ProductListResDTO(
-                50L, 5, page, size, false, productList
-        );
-        return ResponseEntity.ok(body);
+        return ResponseEntity.ok(productQueryService.getProductList(page, size));
     }
 
     @Override
@@ -49,16 +44,7 @@ public class ProductController implements ProductDocs {
     public ResponseEntity<ProductResDTO.ProductDetailResDTO> getProduct(
             @PathVariable Long productId
     ) {
-        ProductResDTO.ProductDetailResDTO body = new ProductResDTO.ProductDetailResDTO(
-                productId,
-                "사과",
-                3000,
-                "과일",
-                "신선한 사과입니다.",
-                "https://example.com/thumb/1.jpg",
-                LocalDateTime.now()
-        );
-        return ResponseEntity.ok(body);
+        return ResponseEntity.ok(productQueryService.getProduct(productId));
     }
 
     @Override
@@ -66,12 +52,7 @@ public class ProductController implements ProductDocs {
     public ResponseEntity<ProductResDTO.CreateProductResDTO> createProduct(
             @Valid @RequestBody ProductReqDTO.CreateProductReqDTO request
     ) {
-        ProductResDTO.CreateProductResDTO body = new ProductResDTO.CreateProductResDTO(
-                51L,
-                request.name(),
-                request.price(),
-                LocalDateTime.now()
-        );
+        ProductResDTO.CreateProductResDTO body = productCommandService.createProduct(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(body);
     }
 

--- a/src/main/java/com/project/likelion14thbe/domain/product/controller/docs/ProductDocs.java
+++ b/src/main/java/com/project/likelion14thbe/domain/product/controller/docs/ProductDocs.java
@@ -2,9 +2,11 @@ package com.project.likelion14thbe.domain.product.controller.docs;
 
 import com.project.likelion14thbe.domain.product.dto.request.ProductReqDTO;
 import com.project.likelion14thbe.domain.product.dto.response.ProductResDTO;
+import com.project.likelion14thbe.global.response.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -22,7 +24,15 @@ public interface ProductDocs {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "상품 목록 조회 성공",
                     content = @Content(schema = @Schema(implementation = ProductResDTO.ProductListResDTO.class))),
-            @ApiResponse(responseCode = "400", description = "잘못된 페이지 파라미터", content = @Content)
+            @ApiResponse(responseCode = "400", description = "잘못된 페이지 파라미터",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "400 Bad Request",
+                                      "message": "잘못된 요청입니다."
+                                    }
+                                    """)))
     })
     ResponseEntity<ProductResDTO.ProductListResDTO> getProductList(
             @Parameter(description = "상품명 검색어 (선택)", example = "사과") String keyword,
@@ -38,7 +48,15 @@ public interface ProductDocs {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "상품 상세 조회 성공",
                     content = @Content(schema = @Schema(implementation = ProductResDTO.ProductDetailResDTO.class))),
-            @ApiResponse(responseCode = "404", description = "상품이 존재하지 않음", content = @Content)
+            @ApiResponse(responseCode = "404", description = "상품이 존재하지 않음",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "404 Not Found",
+                                      "message": "상품이 존재하지 않습니다."
+                                    }
+                                    """)))
     })
     ResponseEntity<ProductResDTO.ProductDetailResDTO> getProduct(
             @Parameter(description = "상품 아이디", example = "1") Long productId
@@ -52,9 +70,33 @@ public interface ProductDocs {
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "상품 등록 성공",
                     content = @Content(schema = @Schema(implementation = ProductResDTO.CreateProductResDTO.class))),
-            @ApiResponse(responseCode = "400", description = "입력 형식 오류", content = @Content),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
-            @ApiResponse(responseCode = "403", description = "관리자 권한 없음", content = @Content)
+            @ApiResponse(responseCode = "400", description = "입력 형식 오류",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "400 Bad Request",
+                                      "message": "잘못된 요청입니다."
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "401 Unauthorized",
+                                      "message": "유효하지 않은 토큰입니다."
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "403 Forbidden",
+                                      "message": "관리자만 상품을 추가할 수 있습니다."
+                                    }
+                                    """)))
     })
     ResponseEntity<ProductResDTO.CreateProductResDTO> createProduct(
             ProductReqDTO.CreateProductReqDTO request
@@ -68,9 +110,33 @@ public interface ProductDocs {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "상품 삭제 성공",
                     content = @Content(schema = @Schema(implementation = ProductResDTO.DeleteProductResDTO.class))),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
-            @ApiResponse(responseCode = "403", description = "관리자 권한 없음", content = @Content),
-            @ApiResponse(responseCode = "404", description = "상품이 존재하지 않음", content = @Content)
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "401 Unauthorized",
+                                      "message": "유효하지 않은 토큰입니다."
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "403 Forbidden",
+                                      "message": "관리자만 상품을 삭제할 수 있습니다."
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "404", description = "상품이 존재하지 않음",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "404 Not Found",
+                                      "message": "상품이 존재하지 않습니다."
+                                    }
+                                    """)))
     })
     ResponseEntity<ProductResDTO.DeleteProductResDTO> deleteProduct(
             @Parameter(description = "상품 아이디", example = "51") Long productId

--- a/src/main/java/com/project/likelion14thbe/domain/product/converter/ProductConverter.java
+++ b/src/main/java/com/project/likelion14thbe/domain/product/converter/ProductConverter.java
@@ -1,8 +1,68 @@
 package com.project.likelion14thbe.domain.product.converter;
 
+import com.project.likelion14thbe.domain.product.dto.request.ProductReqDTO;
+import com.project.likelion14thbe.domain.product.dto.response.ProductResDTO;
+import com.project.likelion14thbe.domain.product.entity.Product;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ProductConverter {
+
+    public static Product toProduct(ProductReqDTO.CreateProductReqDTO request) {
+        return Product.builder()
+                .name(request.name())
+                .price(request.price())
+                .category(request.category())
+                .description(request.description())
+                .build();
+    }
+
+    public static ProductResDTO.CreateProductResDTO toCreateProductResDTO(Product product) {
+        return new ProductResDTO.CreateProductResDTO(
+                product.getId(),
+                product.getName(),
+                product.getPrice(),
+                product.getCreatedAt()
+        );
+    }
+
+    public static ProductResDTO.ProductDetailResDTO toProductDetailResDTO(Product product) {
+        return new ProductResDTO.ProductDetailResDTO(
+                product.getId(),
+                product.getName(),
+                product.getPrice(),
+                product.getCategory(),
+                product.getDescription(),
+                product.getThumbnailUrl(),
+                product.getCreatedAt()
+        );
+    }
+
+    public static ProductResDTO.ProductItemDTO toProductItemDTO(Product product) {
+        return new ProductResDTO.ProductItemDTO(
+                product.getId(),
+                product.getName(),
+                product.getPrice(),
+                product.getCategory(),
+                product.getThumbnailUrl()
+        );
+    }
+
+    public static ProductResDTO.ProductListResDTO toProductListResDTO(Page<Product> page) {
+        List<ProductResDTO.ProductItemDTO> productList = page.getContent().stream()
+                .map(ProductConverter::toProductItemDTO)
+                .toList();
+        return new ProductResDTO.ProductListResDTO(
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.getNumber(),
+                page.getSize(),
+                page.isLast(),
+                productList
+        );
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/product/entity/Product.java
+++ b/src/main/java/com/project/likelion14thbe/domain/product/entity/Product.java
@@ -1,5 +1,42 @@
 package com.project.likelion14thbe.domain.product.entity;
 
-//@Entity
-public class Product {
+import com.project.likelion14thbe.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "product")
+public class Product extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "price", nullable = false)
+    private Integer price;
+
+    @Column(name = "category", nullable = false, length = 50)
+    private String category;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "thumbnail_url", length = 500)
+    private String thumbnailUrl;
 }

--- a/src/main/java/com/project/likelion14thbe/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/project/likelion14thbe/domain/product/repository/ProductRepository.java
@@ -1,4 +1,11 @@
 package com.project.likelion14thbe.domain.product.repository;
 
-public interface ProductRepository {
+import com.project.likelion14thbe.domain.product.entity.Product;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+
+    Page<Product> findAllByOrderByCreatedAtDesc(Pageable pageable);
 }

--- a/src/main/java/com/project/likelion14thbe/domain/product/service/command/ProductCommandService.java
+++ b/src/main/java/com/project/likelion14thbe/domain/product/service/command/ProductCommandService.java
@@ -1,4 +1,9 @@
 package com.project.likelion14thbe.domain.product.service.command;
 
+import com.project.likelion14thbe.domain.product.dto.request.ProductReqDTO;
+import com.project.likelion14thbe.domain.product.dto.response.ProductResDTO;
+
 public interface ProductCommandService {
+
+    ProductResDTO.CreateProductResDTO createProduct(ProductReqDTO.CreateProductReqDTO request);
 }

--- a/src/main/java/com/project/likelion14thbe/domain/product/service/command/ProductCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion14thbe/domain/product/service/command/ProductCommandServiceImpl.java
@@ -1,7 +1,25 @@
 package com.project.likelion14thbe.domain.product.service.command;
 
+import com.project.likelion14thbe.domain.product.converter.ProductConverter;
+import com.project.likelion14thbe.domain.product.dto.request.ProductReqDTO;
+import com.project.likelion14thbe.domain.product.dto.response.ProductResDTO;
+import com.project.likelion14thbe.domain.product.entity.Product;
+import com.project.likelion14thbe.domain.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
+@Transactional
 public class ProductCommandServiceImpl implements ProductCommandService {
+
+    private final ProductRepository productRepository;
+
+    @Override
+    public ProductResDTO.CreateProductResDTO createProduct(ProductReqDTO.CreateProductReqDTO request) {
+        Product product = ProductConverter.toProduct(request);
+        Product saved = productRepository.save(product);
+        return ProductConverter.toCreateProductResDTO(saved);
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/product/service/query/ProductQueryService.java
+++ b/src/main/java/com/project/likelion14thbe/domain/product/service/query/ProductQueryService.java
@@ -1,4 +1,10 @@
 package com.project.likelion14thbe.domain.product.service.query;
 
+import com.project.likelion14thbe.domain.product.dto.response.ProductResDTO;
+
 public interface ProductQueryService {
+
+    ProductResDTO.ProductDetailResDTO getProduct(Long productId);
+
+    ProductResDTO.ProductListResDTO getProductList(Integer page, Integer size);
 }

--- a/src/main/java/com/project/likelion14thbe/domain/product/service/query/ProductQueryServiceImpl.java
+++ b/src/main/java/com/project/likelion14thbe/domain/product/service/query/ProductQueryServiceImpl.java
@@ -23,7 +23,7 @@ public class ProductQueryServiceImpl implements ProductQueryService {
     @Override
     public ProductResDTO.ProductDetailResDTO getProduct(Long productId) {
         Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "상품이 존재하지 않습니다."));
         return ProductConverter.toProductDetailResDTO(product);
     }
 

--- a/src/main/java/com/project/likelion14thbe/domain/product/service/query/ProductQueryServiceImpl.java
+++ b/src/main/java/com/project/likelion14thbe/domain/product/service/query/ProductQueryServiceImpl.java
@@ -1,7 +1,36 @@
 package com.project.likelion14thbe.domain.product.service.query;
 
+import com.project.likelion14thbe.domain.product.converter.ProductConverter;
+import com.project.likelion14thbe.domain.product.dto.response.ProductResDTO;
+import com.project.likelion14thbe.domain.product.entity.Product;
+import com.project.likelion14thbe.domain.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ProductQueryServiceImpl implements ProductQueryService {
+
+    private final ProductRepository productRepository;
+
+    @Override
+    public ProductResDTO.ProductDetailResDTO getProduct(Long productId) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."));
+        return ProductConverter.toProductDetailResDTO(product);
+    }
+
+    @Override
+    public ProductResDTO.ProductListResDTO getProductList(Integer page, Integer size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Product> products = productRepository.findAllByOrderByCreatedAtDesc(pageable);
+        return ProductConverter.toProductListResDTO(products);
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/controller/ReviewController.java
@@ -32,7 +32,7 @@ public class ReviewController implements ReviewDocs {
         ReviewResDTO.CreateReviewResDTO body = new ReviewResDTO.CreateReviewResDTO(
                 123L,
                 productId,
-                "bro",
+                "홍길동",
                 request.rating(),
                 request.content(),
                 LocalDateTime.now()
@@ -49,7 +49,7 @@ public class ReviewController implements ReviewDocs {
         ReviewResDTO.ReviewDetailResDTO body = new ReviewResDTO.ReviewDetailResDTO(
                 reviewId,
                 productId,
-                "bro",
+                "홍길동",
                 4.5,
                 "nice!",
                 LocalDateTime.now(),
@@ -67,8 +67,8 @@ public class ReviewController implements ReviewDocs {
             @RequestParam(defaultValue = "latest") String sort
     ) {
         List<ReviewResDTO.ReviewItemDTO> reviewList = List.of(
-                new ReviewResDTO.ReviewItemDTO(1L, "bro", 4.5, "nice!", LocalDateTime.now()),
-                new ReviewResDTO.ReviewItemDTO(2L, "bro", 5.0, "이 제품 정말 좋아요", LocalDateTime.now())
+                new ReviewResDTO.ReviewItemDTO(1L, "홍길동", 4.5, "nice!", LocalDateTime.now()),
+                new ReviewResDTO.ReviewItemDTO(2L, "홍길동", 5.0, "이 제품 정말 좋아요", LocalDateTime.now())
         );
         ReviewResDTO.ReviewListResDTO body = new ReviewResDTO.ReviewListResDTO(
                 productId, 123L, 13, page, size, false, reviewList
@@ -85,7 +85,7 @@ public class ReviewController implements ReviewDocs {
     ) {
         ReviewResDTO.UpdateReviewResDTO body = new ReviewResDTO.UpdateReviewResDTO(
                 reviewId,
-                "bro",
+                "홍길동",
                 request.rating() != null ? request.rating() : 5.0,
                 request.content() != null ? request.content() : "다시 먹어봤는데 더 맛있네요!",
                 LocalDateTime.now()

--- a/src/main/java/com/project/likelion14thbe/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/controller/ReviewController.java
@@ -3,12 +3,14 @@ package com.project.likelion14thbe.domain.review.controller;
 import com.project.likelion14thbe.domain.review.controller.docs.ReviewDocs;
 import com.project.likelion14thbe.domain.review.dto.request.ReviewReqDTO;
 import com.project.likelion14thbe.domain.review.dto.response.ReviewResDTO;
+import com.project.likelion14thbe.domain.review.service.command.ReviewCommandService;
+import com.project.likelion14thbe.domain.review.service.query.ReviewQueryService;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -21,22 +23,21 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1")
+@RequiredArgsConstructor
 public class ReviewController implements ReviewDocs {
+
+    private final ReviewCommandService reviewCommandService;
+    private final ReviewQueryService reviewQueryService;
 
     @Override
     @PostMapping("/products/{productId}/reviews")
     public ResponseEntity<ReviewResDTO.CreateReviewResDTO> createReview(
             @PathVariable Long productId,
+            @RequestParam Long memberId,
             @Valid @RequestBody ReviewReqDTO.CreateReviewReqDTO request
     ) {
-        ReviewResDTO.CreateReviewResDTO body = new ReviewResDTO.CreateReviewResDTO(
-                123L,
-                productId,
-                "홍길동",
-                request.rating(),
-                request.content(),
-                LocalDateTime.now()
-        );
+        ReviewResDTO.CreateReviewResDTO body =
+                reviewCommandService.createReview(memberId, productId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(body);
     }
 
@@ -46,16 +47,7 @@ public class ReviewController implements ReviewDocs {
             @PathVariable Long productId,
             @PathVariable Long reviewId
     ) {
-        ReviewResDTO.ReviewDetailResDTO body = new ReviewResDTO.ReviewDetailResDTO(
-                reviewId,
-                productId,
-                "홍길동",
-                4.5,
-                "nice!",
-                LocalDateTime.now(),
-                LocalDateTime.now()
-        );
-        return ResponseEntity.ok(body);
+        return ResponseEntity.ok(reviewQueryService.getReview(productId, reviewId));
     }
 
     @Override
@@ -66,14 +58,7 @@ public class ReviewController implements ReviewDocs {
             @RequestParam(defaultValue = "10") Integer size,
             @RequestParam(defaultValue = "latest") String sort
     ) {
-        List<ReviewResDTO.ReviewItemDTO> reviewList = List.of(
-                new ReviewResDTO.ReviewItemDTO(1L, "홍길동", 4.5, "nice!", LocalDateTime.now()),
-                new ReviewResDTO.ReviewItemDTO(2L, "홍길동", 5.0, "이 제품 정말 좋아요", LocalDateTime.now())
-        );
-        ReviewResDTO.ReviewListResDTO body = new ReviewResDTO.ReviewListResDTO(
-                productId, 123L, 13, page, size, false, reviewList
-        );
-        return ResponseEntity.ok(body);
+        return ResponseEntity.ok(reviewQueryService.getReviewList(productId, page, size, sort));
     }
 
     @Override
@@ -109,18 +94,10 @@ public class ReviewController implements ReviewDocs {
     @Override
     @GetMapping("/members/me/reviews")
     public ResponseEntity<ReviewResDTO.MyReviewListResDTO> getMyReviews(
+            @RequestParam Long memberId,
             @RequestParam(defaultValue = "0") Integer page,
             @RequestParam(defaultValue = "10") Integer size
     ) {
-        List<ReviewResDTO.MyReviewItemDTO> reviewList = List.of(
-                new ReviewResDTO.MyReviewItemDTO(
-                        1L, 5L, "사과", 4.5, "nice!",
-                        LocalDateTime.now(), LocalDateTime.now()
-                )
-        );
-        ReviewResDTO.MyReviewListResDTO body = new ReviewResDTO.MyReviewListResDTO(
-                7L, 1, page, size, true, reviewList
-        );
-        return ResponseEntity.ok(body);
+        return ResponseEntity.ok(reviewQueryService.getMyReviews(memberId, page, size));
     }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/review/controller/docs/ReviewDocs.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/controller/docs/ReviewDocs.java
@@ -18,18 +18,19 @@ public interface ReviewDocs {
 
     @Operation(
             summary = "리뷰 생성",
-            description = "특정 상품에 대해 새로운 리뷰를 생성한다. 동일 상품에 1인 1회 작성 제한."
+            description = "특정 상품에 대해 새로운 리뷰를 생성한다. 동일 상품에 1인 1회 작성 제한. (JWT 적용 전까지 memberId는 임시 query 파라미터)"
     )
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "리뷰 생성 성공",
                     content = @Content(schema = @Schema(implementation = ReviewResDTO.CreateReviewResDTO.class))),
             @ApiResponse(responseCode = "400", description = "별점 범위 초과 또는 리뷰 내용 누락", content = @Content),
             @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
-            @ApiResponse(responseCode = "404", description = "상품이 존재하지 않음", content = @Content),
+            @ApiResponse(responseCode = "404", description = "회원 또는 상품이 존재하지 않음", content = @Content),
             @ApiResponse(responseCode = "409", description = "이미 해당 상품에 리뷰를 작성함", content = @Content)
     })
     ResponseEntity<ReviewResDTO.CreateReviewResDTO> createReview(
             @Parameter(description = "상품 아이디", example = "5") Long productId,
+            @Parameter(description = "작성자 회원 ID (JWT 적용 전 임시)", example = "1") Long memberId,
             ReviewReqDTO.CreateReviewReqDTO request
     );
 
@@ -103,15 +104,17 @@ public interface ReviewDocs {
 
     @Operation(
             summary = "내 리뷰 조회",
-            description = "현재 로그인한 회원이 작성한 모든 리뷰를 페이징 조회한다."
+            description = "현재 로그인한 회원이 작성한 모든 리뷰를 페이징 조회한다. (JWT 적용 전까지 memberId는 임시 query 파라미터)"
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "내 리뷰 조회 성공",
                     content = @Content(schema = @Schema(implementation = ReviewResDTO.MyReviewListResDTO.class))),
             @ApiResponse(responseCode = "400", description = "잘못된 페이지 파라미터", content = @Content),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content)
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
+            @ApiResponse(responseCode = "404", description = "회원이 존재하지 않음", content = @Content)
     })
     ResponseEntity<ReviewResDTO.MyReviewListResDTO> getMyReviews(
+            @Parameter(description = "조회 회원 ID (JWT 적용 전 임시)", example = "1") Long memberId,
             @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") Integer page,
             @Parameter(description = "페이지당 개수", example = "10") Integer size
     );

--- a/src/main/java/com/project/likelion14thbe/domain/review/controller/docs/ReviewDocs.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/controller/docs/ReviewDocs.java
@@ -2,9 +2,11 @@ package com.project.likelion14thbe.domain.review.controller.docs;
 
 import com.project.likelion14thbe.domain.review.dto.request.ReviewReqDTO;
 import com.project.likelion14thbe.domain.review.dto.response.ReviewResDTO;
+import com.project.likelion14thbe.global.response.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -23,10 +25,60 @@ public interface ReviewDocs {
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "리뷰 생성 성공",
                     content = @Content(schema = @Schema(implementation = ReviewResDTO.CreateReviewResDTO.class))),
-            @ApiResponse(responseCode = "400", description = "별점 범위 초과 또는 리뷰 내용 누락", content = @Content),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
-            @ApiResponse(responseCode = "404", description = "회원 또는 상품이 존재하지 않음", content = @Content),
-            @ApiResponse(responseCode = "409", description = "이미 해당 상품에 리뷰를 작성함", content = @Content)
+            @ApiResponse(responseCode = "400", description = "별점 범위 초과 또는 리뷰 내용 누락",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "별점 범위 초과", value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "400 Bad Request",
+                                              "message": "별점은 0.5 이상 5.0 이하여야 합니다."
+                                            }
+                                            """),
+                                    @ExampleObject(name = "리뷰 내용 누락", value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "400 Bad Request",
+                                              "message": "리뷰 내용은 필수입니다."
+                                            }
+                                            """)
+                            })),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "401 Unauthorized",
+                                      "message": "유효하지 않은 토큰입니다."
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "404", description = "회원 또는 상품이 존재하지 않음",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "상품 미존재", value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "404 Not Found",
+                                              "message": "상품이 존재하지 않습니다."
+                                            }
+                                            """),
+                                    @ExampleObject(name = "회원 미존재", value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "404 Not Found",
+                                              "message": "회원을 찾을 수 없습니다."
+                                            }
+                                            """)
+                            })),
+            @ApiResponse(responseCode = "409", description = "이미 해당 상품에 리뷰를 작성함",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "409 Conflict",
+                                      "message": "이미 해당 상품에 리뷰를 작성했습니다."
+                                    }
+                                    """)))
     })
     ResponseEntity<ReviewResDTO.CreateReviewResDTO> createReview(
             @Parameter(description = "상품 아이디", example = "5") Long productId,
@@ -41,8 +93,33 @@ public interface ReviewDocs {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "리뷰 단건 조회 성공",
                     content = @Content(schema = @Schema(implementation = ReviewResDTO.ReviewDetailResDTO.class))),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
-            @ApiResponse(responseCode = "404", description = "상품 또는 리뷰가 존재하지 않음", content = @Content)
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "401 Unauthorized",
+                                      "message": "유효하지 않은 토큰입니다."
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "404", description = "상품 또는 리뷰가 존재하지 않음",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "리뷰 미존재", value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "404 Not Found",
+                                              "message": "리뷰가 존재하지 않습니다."
+                                            }
+                                            """),
+                                    @ExampleObject(name = "상품 미존재", value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "404 Not Found",
+                                              "message": "상품이 존재하지 않습니다."
+                                            }
+                                            """)
+                            }))
     })
     ResponseEntity<ReviewResDTO.ReviewDetailResDTO> getReview(
             @Parameter(description = "상품 아이디", example = "5") Long productId,
@@ -56,9 +133,33 @@ public interface ReviewDocs {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "리뷰 목록 조회 성공",
                     content = @Content(schema = @Schema(implementation = ReviewResDTO.ReviewListResDTO.class))),
-            @ApiResponse(responseCode = "400", description = "잘못된 페이지 파라미터", content = @Content),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
-            @ApiResponse(responseCode = "404", description = "상품이 존재하지 않음", content = @Content)
+            @ApiResponse(responseCode = "400", description = "잘못된 페이지/정렬 파라미터",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "400 Bad Request",
+                                      "message": "잘못된 요청입니다."
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "401 Unauthorized",
+                                      "message": "유효하지 않은 토큰입니다."
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "404", description = "상품이 존재하지 않음",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "404 Not Found",
+                                      "message": "상품이 존재하지 않습니다."
+                                    }
+                                    """)))
     })
     ResponseEntity<ReviewResDTO.ReviewListResDTO> getReviewList(
             @Parameter(description = "상품 아이디", example = "5") Long productId,
@@ -75,10 +176,51 @@ public interface ReviewDocs {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "리뷰 수정 성공",
                     content = @Content(schema = @Schema(implementation = ReviewResDTO.UpdateReviewResDTO.class))),
-            @ApiResponse(responseCode = "400", description = "별점 범위 초과", content = @Content),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
-            @ApiResponse(responseCode = "403", description = "본인이 작성한 리뷰가 아님", content = @Content),
-            @ApiResponse(responseCode = "404", description = "리뷰가 존재하지 않음", content = @Content)
+            @ApiResponse(responseCode = "400", description = "별점 범위 초과 또는 수정 항목 누락",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "별점 범위 초과", value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "400 Bad Request",
+                                              "message": "별점은 0.5 이상 5.0 이하여야 합니다."
+                                            }
+                                            """),
+                                    @ExampleObject(name = "수정 항목 누락 (PATCH 최소 1개 필수)", value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "400 Bad Request",
+                                              "message": "수정할 항목을 1개 이상 입력해주세요."
+                                            }
+                                            """)
+                            })),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "401 Unauthorized",
+                                      "message": "유효하지 않은 토큰입니다."
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "403", description = "본인이 작성한 리뷰가 아님",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "403 Forbidden",
+                                      "message": "본인이 작성한 리뷰만 수정할 수 있습니다."
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "404", description = "리뷰가 존재하지 않음",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "404 Not Found",
+                                      "message": "리뷰가 존재하지 않습니다."
+                                    }
+                                    """)))
     })
     ResponseEntity<ReviewResDTO.UpdateReviewResDTO> updateReview(
             @Parameter(description = "상품 아이디", example = "5") Long productId,
@@ -93,9 +235,33 @@ public interface ReviewDocs {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "리뷰 삭제 성공",
                     content = @Content(schema = @Schema(implementation = ReviewResDTO.DeleteReviewResDTO.class))),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
-            @ApiResponse(responseCode = "403", description = "본인이 작성한 리뷰가 아님", content = @Content),
-            @ApiResponse(responseCode = "404", description = "리뷰가 존재하지 않음", content = @Content)
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "401 Unauthorized",
+                                      "message": "유효하지 않은 토큰입니다."
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "403", description = "본인이 작성한 리뷰가 아님",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "403 Forbidden",
+                                      "message": "본인이 작성한 리뷰만 삭제할 수 있습니다."
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "404", description = "리뷰가 존재하지 않음",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "404 Not Found",
+                                      "message": "리뷰가 존재하지 않습니다."
+                                    }
+                                    """)))
     })
     ResponseEntity<ReviewResDTO.DeleteReviewResDTO> deleteReview(
             @Parameter(description = "상품 아이디", example = "5") Long productId,
@@ -109,9 +275,33 @@ public interface ReviewDocs {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "내 리뷰 조회 성공",
                     content = @Content(schema = @Schema(implementation = ReviewResDTO.MyReviewListResDTO.class))),
-            @ApiResponse(responseCode = "400", description = "잘못된 페이지 파라미터", content = @Content),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰", content = @Content),
-            @ApiResponse(responseCode = "404", description = "회원이 존재하지 않음", content = @Content)
+            @ApiResponse(responseCode = "400", description = "잘못된 페이지 파라미터",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "400 Bad Request",
+                                      "message": "잘못된 요청입니다."
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "401 Unauthorized",
+                                      "message": "유효하지 않은 토큰입니다."
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "404", description = "회원이 존재하지 않음",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "404 Not Found",
+                                      "message": "회원을 찾을 수 없습니다."
+                                    }
+                                    """)))
     })
     ResponseEntity<ReviewResDTO.MyReviewListResDTO> getMyReviews(
             @Parameter(description = "조회 회원 ID (JWT 적용 전 임시)", example = "1") Long memberId,

--- a/src/main/java/com/project/likelion14thbe/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/converter/ReviewConverter.java
@@ -1,8 +1,103 @@
 package com.project.likelion14thbe.domain.review.converter;
 
+import com.project.likelion14thbe.domain.member.entity.Member;
+import com.project.likelion14thbe.domain.product.entity.Product;
+import com.project.likelion14thbe.domain.review.dto.request.ReviewReqDTO;
+import com.project.likelion14thbe.domain.review.dto.response.ReviewResDTO;
+import com.project.likelion14thbe.domain.review.entity.Review;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ReviewConverter {
+
+    public static Review toReview(
+            Member member,
+            Product product,
+            ReviewReqDTO.CreateReviewReqDTO request
+    ) {
+        return Review.builder()
+                .member(member)
+                .product(product)
+                .rating(request.rating())
+                .content(request.content())
+                .build();
+    }
+
+    public static ReviewResDTO.CreateReviewResDTO toCreateReviewResDTO(Review review) {
+        return new ReviewResDTO.CreateReviewResDTO(
+                review.getId(),
+                review.getProduct().getId(),
+                review.getMember().getName(),
+                review.getRating(),
+                review.getContent(),
+                review.getCreatedAt()
+        );
+    }
+
+    public static ReviewResDTO.ReviewDetailResDTO toReviewDetailResDTO(Review review) {
+        return new ReviewResDTO.ReviewDetailResDTO(
+                review.getId(),
+                review.getProduct().getId(),
+                review.getMember().getName(),
+                review.getRating(),
+                review.getContent(),
+                review.getCreatedAt(),
+                review.getUpdatedAt()
+        );
+    }
+
+    public static ReviewResDTO.ReviewItemDTO toReviewItemDTO(Review review) {
+        return new ReviewResDTO.ReviewItemDTO(
+                review.getId(),
+                review.getMember().getName(),
+                review.getRating(),
+                review.getContent(),
+                review.getCreatedAt()
+        );
+    }
+
+    public static ReviewResDTO.ReviewListResDTO toReviewListResDTO(Long productId, Page<Review> page) {
+        List<ReviewResDTO.ReviewItemDTO> reviewList = page.getContent().stream()
+                .map(ReviewConverter::toReviewItemDTO)
+                .toList();
+        return new ReviewResDTO.ReviewListResDTO(
+                productId,
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.getNumber(),
+                page.getSize(),
+                page.isLast(),
+                reviewList
+        );
+    }
+
+    public static ReviewResDTO.MyReviewItemDTO toMyReviewItemDTO(Review review) {
+        return new ReviewResDTO.MyReviewItemDTO(
+                review.getId(),
+                review.getProduct().getId(),
+                review.getProduct().getName(),
+                review.getRating(),
+                review.getContent(),
+                review.getCreatedAt(),
+                review.getUpdatedAt()
+        );
+    }
+
+    public static ReviewResDTO.MyReviewListResDTO toMyReviewListResDTO(Page<Review> page) {
+        List<ReviewResDTO.MyReviewItemDTO> reviewList = page.getContent().stream()
+                .map(ReviewConverter::toMyReviewItemDTO)
+                .toList();
+        return new ReviewResDTO.MyReviewListResDTO(
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.getNumber(),
+                page.getSize(),
+                page.isLast(),
+                reviewList
+        );
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/review/dto/response/ReviewResDTO.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/dto/response/ReviewResDTO.java
@@ -13,7 +13,7 @@ public class ReviewResDTO {
             Long reviewId,
             @Schema(description = "상품 ID", example = "5")
             Long productId,
-            @Schema(description = "작성자 닉네임", example = "bro")
+            @Schema(description = "작성자 이름", example = "홍길동")
             String writerNickname,
             @Schema(description = "별점", example = "4.5")
             Double rating,
@@ -30,7 +30,7 @@ public class ReviewResDTO {
             Long reviewId,
             @Schema(description = "상품 ID", example = "5")
             Long productId,
-            @Schema(description = "작성자 닉네임", example = "bro")
+            @Schema(description = "작성자 이름", example = "홍길동")
             String writerNickname,
             @Schema(description = "별점", example = "4.5")
             Double rating,
@@ -47,7 +47,7 @@ public class ReviewResDTO {
     public record ReviewItemDTO(
             @Schema(description = "리뷰 ID", example = "1")
             Long reviewId,
-            @Schema(description = "작성자 닉네임", example = "bro")
+            @Schema(description = "작성자 이름", example = "홍길동")
             String writerNickname,
             @Schema(description = "별점", example = "4.5")
             Double rating,
@@ -81,7 +81,7 @@ public class ReviewResDTO {
     public record UpdateReviewResDTO(
             @Schema(description = "리뷰 ID", example = "123")
             Long reviewId,
-            @Schema(description = "작성자 닉네임", example = "bro")
+            @Schema(description = "작성자 이름", example = "홍길동")
             String writerNickname,
             @Schema(description = "별점", example = "5.0")
             Double rating,

--- a/src/main/java/com/project/likelion14thbe/domain/review/entity/Review.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/entity/Review.java
@@ -1,5 +1,46 @@
 package com.project.likelion14thbe.domain.review.entity;
 
-//@Entity
-public class Review {
+import com.project.likelion14thbe.domain.member.entity.Member;
+import com.project.likelion14thbe.domain.product.entity.Product;
+import com.project.likelion14thbe.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "review")
+public class Review extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Column(name = "rating", nullable = false)
+    private Double rating;
+
+    @Column(name = "content", columnDefinition = "TEXT", nullable = false)
+    private String content;
 }

--- a/src/main/java/com/project/likelion14thbe/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/repository/ReviewRepository.java
@@ -1,4 +1,15 @@
 package com.project.likelion14thbe.domain.review.repository;
 
-public interface ReviewRepository {
+import com.project.likelion14thbe.domain.review.entity.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    Page<Review> findAllByProduct_Id(Long productId, Pageable pageable);
+
+    Page<Review> findAllByMember_IdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
+
+    boolean existsByMember_IdAndProduct_Id(Long memberId, Long productId);
 }

--- a/src/main/java/com/project/likelion14thbe/domain/review/service/command/ReviewCommandService.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/service/command/ReviewCommandService.java
@@ -1,4 +1,13 @@
 package com.project.likelion14thbe.domain.review.service.command;
 
+import com.project.likelion14thbe.domain.review.dto.request.ReviewReqDTO;
+import com.project.likelion14thbe.domain.review.dto.response.ReviewResDTO;
+
 public interface ReviewCommandService {
+
+    ReviewResDTO.CreateReviewResDTO createReview(
+            Long memberId,
+            Long productId,
+            ReviewReqDTO.CreateReviewReqDTO request
+    );
 }

--- a/src/main/java/com/project/likelion14thbe/domain/review/service/command/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/service/command/ReviewCommandServiceImpl.java
@@ -1,7 +1,46 @@
 package com.project.likelion14thbe.domain.review.service.command;
 
+import com.project.likelion14thbe.domain.member.entity.Member;
+import com.project.likelion14thbe.domain.member.repository.MemberRepository;
+import com.project.likelion14thbe.domain.product.entity.Product;
+import com.project.likelion14thbe.domain.product.repository.ProductRepository;
+import com.project.likelion14thbe.domain.review.converter.ReviewConverter;
+import com.project.likelion14thbe.domain.review.dto.request.ReviewReqDTO;
+import com.project.likelion14thbe.domain.review.dto.response.ReviewResDTO;
+import com.project.likelion14thbe.domain.review.entity.Review;
+import com.project.likelion14thbe.domain.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
+@RequiredArgsConstructor
+@Transactional
 public class ReviewCommandServiceImpl implements ReviewCommandService {
+
+    private final ReviewRepository reviewRepository;
+    private final MemberRepository memberRepository;
+    private final ProductRepository productRepository;
+
+    @Override
+    public ReviewResDTO.CreateReviewResDTO createReview(
+            Long memberId,
+            Long productId,
+            ReviewReqDTO.CreateReviewReqDTO request
+    ) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."));
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."));
+
+        if (reviewRepository.existsByMember_IdAndProduct_Id(memberId, productId)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 해당 상품에 리뷰를 작성했습니다.");
+        }
+
+        Review review = ReviewConverter.toReview(member, product, request);
+        Review saved = reviewRepository.save(review);
+        return ReviewConverter.toCreateReviewResDTO(saved);
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/review/service/command/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/service/command/ReviewCommandServiceImpl.java
@@ -33,7 +33,7 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."));
         Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "상품이 존재하지 않습니다."));
 
         if (reviewRepository.existsByMember_IdAndProduct_Id(memberId, productId)) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 해당 상품에 리뷰를 작성했습니다.");

--- a/src/main/java/com/project/likelion14thbe/domain/review/service/query/ReviewQueryService.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/service/query/ReviewQueryService.java
@@ -1,4 +1,12 @@
 package com.project.likelion14thbe.domain.review.service.query;
 
+import com.project.likelion14thbe.domain.review.dto.response.ReviewResDTO;
+
 public interface ReviewQueryService {
+
+    ReviewResDTO.ReviewDetailResDTO getReview(Long productId, Long reviewId);
+
+    ReviewResDTO.ReviewListResDTO getReviewList(Long productId, Integer page, Integer size, String sort);
+
+    ReviewResDTO.MyReviewListResDTO getMyReviews(Long memberId, Integer page, Integer size);
 }

--- a/src/main/java/com/project/likelion14thbe/domain/review/service/query/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/service/query/ReviewQueryServiceImpl.java
@@ -28,7 +28,7 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
     @Override
     public ReviewResDTO.ReviewDetailResDTO getReview(Long productId, Long reviewId) {
         Review review = reviewRepository.findById(reviewId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "리뷰를 찾을 수 없습니다."));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "리뷰가 존재하지 않습니다."));
         if (!review.getProduct().getId().equals(productId)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "해당 상품의 리뷰가 아닙니다.");
         }
@@ -38,7 +38,7 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
     @Override
     public ReviewResDTO.ReviewListResDTO getReviewList(Long productId, Integer page, Integer size, String sort) {
         if (!productRepository.existsById(productId)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다.");
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "상품이 존재하지 않습니다.");
         }
         Sort sortOption = "rating".equals(sort)
                 ? Sort.by(Sort.Direction.DESC, "rating")

--- a/src/main/java/com/project/likelion14thbe/domain/review/service/query/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/service/query/ReviewQueryServiceImpl.java
@@ -1,7 +1,60 @@
 package com.project.likelion14thbe.domain.review.service.query;
 
+import com.project.likelion14thbe.domain.member.repository.MemberRepository;
+import com.project.likelion14thbe.domain.product.repository.ProductRepository;
+import com.project.likelion14thbe.domain.review.converter.ReviewConverter;
+import com.project.likelion14thbe.domain.review.dto.response.ReviewResDTO;
+import com.project.likelion14thbe.domain.review.entity.Review;
+import com.project.likelion14thbe.domain.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ReviewQueryServiceImpl implements ReviewQueryService {
+
+    private final ReviewRepository reviewRepository;
+    private final MemberRepository memberRepository;
+    private final ProductRepository productRepository;
+
+    @Override
+    public ReviewResDTO.ReviewDetailResDTO getReview(Long productId, Long reviewId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "리뷰를 찾을 수 없습니다."));
+        if (!review.getProduct().getId().equals(productId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "해당 상품의 리뷰가 아닙니다.");
+        }
+        return ReviewConverter.toReviewDetailResDTO(review);
+    }
+
+    @Override
+    public ReviewResDTO.ReviewListResDTO getReviewList(Long productId, Integer page, Integer size, String sort) {
+        if (!productRepository.existsById(productId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다.");
+        }
+        Sort sortOption = "rating".equals(sort)
+                ? Sort.by(Sort.Direction.DESC, "rating")
+                : Sort.by(Sort.Direction.DESC, "createdAt");
+        Pageable pageable = PageRequest.of(page, size, sortOption);
+        Page<Review> reviews = reviewRepository.findAllByProduct_Id(productId, pageable);
+        return ReviewConverter.toReviewListResDTO(productId, reviews);
+    }
+
+    @Override
+    public ReviewResDTO.MyReviewListResDTO getMyReviews(Long memberId, Integer page, Integer size) {
+        if (!memberRepository.existsById(memberId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다.");
+        }
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Review> reviews = reviewRepository.findAllByMember_IdOrderByCreatedAtDesc(memberId, pageable);
+        return ReviewConverter.toMyReviewListResDTO(reviews);
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/global/common/BaseEntity.java
+++ b/src/main/java/com/project/likelion14thbe/global/common/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.project.likelion14thbe.global.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/project/likelion14thbe/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/likelion14thbe/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,54 @@
+package com.project.likelion14thbe.global.exception;
+
+import com.project.likelion14thbe.global.response.CustomResponse;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<CustomResponse<Void>> handleResponseStatusException(ResponseStatusException ex) {
+        HttpStatusCode statusCode = ex.getStatusCode();
+        String message = ex.getReason() != null ? ex.getReason() : "요청 처리에 실패했습니다.";
+        return ResponseEntity.status(statusCode)
+                .body(CustomResponse.fail(toCode(statusCode), message));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<CustomResponse<Void>> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .orElse("요청 값이 올바르지 않습니다.");
+        return ResponseEntity.badRequest()
+                .body(CustomResponse.fail(toCode(HttpStatus.BAD_REQUEST), message));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<CustomResponse<Void>> handleConstraintViolation(ConstraintViolationException ex) {
+        return ResponseEntity.badRequest()
+                .body(CustomResponse.fail(toCode(HttpStatus.BAD_REQUEST), "요청 값이 올바르지 않습니다."));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CustomResponse<Void>> handleException(Exception ex) {
+        return ResponseEntity.internalServerError()
+                .body(CustomResponse.fail(toCode(HttpStatus.INTERNAL_SERVER_ERROR), "서버 내부 오류가 발생했습니다."));
+    }
+
+    private String toCode(HttpStatusCode statusCode) {
+        HttpStatus status = HttpStatus.resolve(statusCode.value());
+        if (status == null) {
+            return String.valueOf(statusCode.value());
+        }
+        return status.value() + " " + status.getReasonPhrase();
+    }
+}

--- a/src/main/java/com/project/likelion14thbe/global/response/CustomResponse.java
+++ b/src/main/java/com/project/likelion14thbe/global/response/CustomResponse.java
@@ -1,0 +1,19 @@
+package com.project.likelion14thbe.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CustomResponse<T>(
+        boolean isSuccess,
+        String code,
+        String message,
+        T result
+) {
+    public static <T> CustomResponse<T> fail(String code, String message) {
+        return new CustomResponse<>(false, code, message, null);
+    }
+
+    public static <T> CustomResponse<T> success(String code, String message, T result) {
+        return new CustomResponse<>(true, code, message, result);
+    }
+}


### PR DESCRIPTION
# ☝️Issue Number

- #55

## 📌 개요

- 4주차 필수 항목인 **Member 도메인 CR**과 선택 항목인 **Product/Order/Review CR**까지 일괄 구현
- 3주차에서 dummy로 두었던 Service 계층을 실제 JPA + Repository로 연결, Controller mock 제거
- `RestControllerAdvice` 기반 **Global Exception Handler + CustomResponse envelope** 도입으로 4xx/5xx 응답을 옵시디언 가이드 §6 표준에 일치
- Swagger `@ApiResponses` 예시를 envelope 형태로 4도메인 일괄 갱신

## 🔁 변경 사항

### 환경 세팅 (1)
- `build.gradle`에 Spring Data JPA Starter + MySQL Connector 추가
- `Likelion14thbeApplication`에 `@EnableJpaAuditing`
- `BaseEntity`(`@MappedSuperclass + AuditingEntityListener`) 추가 — `createdAt/updatedAt`

### Member 도메인 (8커밋)
- 엔티티: BaseEntity 상속, `@Entity/@Table(name="member")`, `email unique`
- DTO: 카카오 로그인 관련 DTO 제거, `nickname → name` 정리
- Converter: `toMember/toSignUpResDTO/toMyInfoResDTO` 정적 팩토리
- Repository: `findByEmail`, `existsByEmail`
- 회원가입 Service: 이메일 중복 시 **409 Conflict**
- 내 정보 조회 Service: 회원 미존재 시 **404 Not Found** (현재는 `@RequestParam memberId` placeholder, 5주차 JWT로 대체 예정)
- 로그인 Service: 이메일 미존재 **404**, 비밀번호 불일치 **401** (JWT는 dummy 상수 유지)
- 카카오 라우트 제거 (3주차 정리)

### Product 도메인 (3커밋)
- 엔티티 BaseEntity 상속 + Repository
- Converter + CR Service (CQRS, 단건 조회 404)
- Controller mock 제거 (`DELETE`는 다음 이슈)

### Order 도메인 (4커밋)
- 엔티티 BaseEntity 상속 + `Member`/`Product` `ManyToOne(LAZY)` + Repository
- Converter
- CR Service (Member+Product FK 검증, CQRS)
- Controller mock 제거 (`memberId` 임시 파라미터)

### Review 도메인 (4커밋)
- 엔티티 BaseEntity 상속 + `Member`/`Product` `ManyToOne(LAZY)` + Repository
- Converter
- CR Service: Member+Product FK 검증, **1인 1리뷰 409 Conflict**
- Controller mock 제거 (`PATCH/DELETE`는 mock 유지)

### 글로벌 (3커밋)
- `GlobalExceptionHandler`: `ResponseStatusException` / `MethodArgumentNotValidException` / `ConstraintViolationException` / `Exception` 4종 핸들링
- `CustomResponse<T>` record (`isSuccess/code/message/result`) — `@JsonInclude(NON_NULL)`
- 코드 포맷 `"404 Not Found"` 등 옵시디언 가이드 §6 일치
- 4도메인 Service 에러 메시지를 3주차 API 명세서와 통일
- 4도메인 Swagger Docs envelope 예시 일괄 추가

## 📸 스크린샷

(추후 Swagger UI 캡처 첨부 예정)

## 👀 기타 더 이야기해볼 점

- **Review 1인 1리뷰는 Service 계층의 `existsBy...` 체크만 존재** → 동시 POST 2건이 들어오면 race condition 가능. 다음주에 `Review` 엔티티에 `@UniqueConstraint(member_id, product_id)` 추가 또는 `@Lock` 적용 검토
- `GlobalExceptionHandler.handleException(Exception)`이 마지막 폴백인데 로깅이 없음 → 5xx 원인 추적 위해 `log.error` 추가 필요
- `@RequestParam memberId` placeholder는 JWT 인증 컨텍스트로 교체 예정 
