### PR TITLE
✨feat: 6주차 과제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,14 @@ dependencies {
 	// Lombok
 	annotationProcessor 'org.projectlombok:lombok'
 	compileOnly 'org.projectlombok:lombok'
+
+	// JWT (jjwt 0.13)
+	implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
+
+	// Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/project/likelion14thbe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/controller/AuthController.java
@@ -19,4 +19,11 @@ public class AuthController implements AuthDocs {
     public CustomResponse<JwtDTO> login(@RequestBody MemberReqDTO.LoginReqDTO request) {
         throw new UnsupportedOperationException("로그인은 CustomLoginFilter가 처리한다.");
     }
+
+    // Spring Security LogoutFilter가 /api/v1/auth/logout 요청을 가로채 CustomLogoutHandler를 호출하므로 이 메서드는 호출되지 않는다.
+    @Override
+    @PostMapping("/auth/logout")
+    public CustomResponse<String> logout() {
+        throw new UnsupportedOperationException("로그아웃은 Spring Security LogoutFilter가 처리한다.");
+    }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/controller/AuthController.java
@@ -1,0 +1,22 @@
+package com.project.likelion14thbe.domain.auth.controller;
+
+import com.project.likelion14thbe.domain.auth.controller.docs.AuthDocs;
+import com.project.likelion14thbe.domain.auth.dto.response.JwtDTO;
+import com.project.likelion14thbe.domain.member.dto.request.MemberReqDTO;
+import com.project.likelion14thbe.global.apiPayload.CustomResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class AuthController implements AuthDocs {
+
+    // CustomLoginFilter가 /api/v1/login 요청을 가로채 직접 인증을 처리하므로 이 메서드는 호출되지 않는다.
+    @Override
+    @PostMapping("/login")
+    public CustomResponse<JwtDTO> login(@RequestBody MemberReqDTO.LoginReqDTO request) {
+        throw new UnsupportedOperationException("로그인은 CustomLoginFilter가 처리한다.");
+    }
+}

--- a/src/main/java/com/project/likelion14thbe/domain/auth/controller/docs/AuthDocs.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/controller/docs/AuthDocs.java
@@ -1,0 +1,38 @@
+package com.project.likelion14thbe.domain.auth.controller.docs;
+
+import com.project.likelion14thbe.domain.auth.dto.response.JwtDTO;
+import com.project.likelion14thbe.domain.member.dto.request.MemberReqDTO;
+import com.project.likelion14thbe.global.apiPayload.CustomResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Auth", description = "인증 API — 로그인은 Spring Security 필터(CustomLoginFilter)가 직접 처리한다. 이 컨트롤러는 Swagger 문서 노출 전용.")
+public interface AuthDocs {
+
+    @Operation(
+            summary = "로그인",
+            description = "이메일·비밀번호로 인증하여 accessToken·refreshToken을 발급한다. " +
+                    "실제 처리는 CustomLoginFilter.attemptAuthentication / successfulAuthentication 에서 수행되며, " +
+                    "이 메서드 본문은 호출되지 않는다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공",
+                    content = @Content(schema = @Schema(implementation = JwtDTO.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패 (이메일 없음·비밀번호 불일치)",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "AUTH401_1",
+                                      "message": "이메일 또는 비밀번호가 잘못되었습니다.",
+                                      "result": null
+                                    }
+                                    """)))
+    })
+    CustomResponse<JwtDTO> login(MemberReqDTO.LoginReqDTO request);
+}

--- a/src/main/java/com/project/likelion14thbe/domain/auth/controller/docs/AuthDocs.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/controller/docs/AuthDocs.java
@@ -9,9 +9,10 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "Auth", description = "인증 API — 로그인은 Spring Security 필터(CustomLoginFilter)가 직접 처리한다. 이 컨트롤러는 Swagger 문서 노출 전용.")
+@Tag(name = "Auth", description = "인증 API — 로그인·로그아웃은 Spring Security 필터가 직접 처리한다. 이 컨트롤러는 Swagger 문서 노출 전용.")
 public interface AuthDocs {
 
     @Operation(
@@ -35,4 +36,27 @@ public interface AuthDocs {
                                     """)))
     })
     CustomResponse<JwtDTO> login(MemberReqDTO.LoginReqDTO request);
+
+    @Operation(
+            summary = "로그아웃",
+            description = "Refresh Token을 DB에서 삭제하여 access token 재발급을 차단한다. " +
+                    "실제 처리는 Spring Security LogoutFilter → CustomLogoutHandler 에서 수행되며, " +
+                    "이 메서드 본문은 호출되지 않는다."
+    )
+    @SecurityRequirement(name = "JWT TOKEN")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "200",
+                                      "message": "OK",
+                                      "result": "로그아웃 성공"
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 없음·만료·위조",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class)))
+    })
+    CustomResponse<String> logout();
 }

--- a/src/main/java/com/project/likelion14thbe/domain/auth/dto/response/JwtDTO.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/dto/response/JwtDTO.java
@@ -1,0 +1,14 @@
+package com.project.likelion14thbe.domain.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "JWT 토큰 응답 DTO")
+@Builder
+public record JwtDTO(
+        @Schema(description = "JWT Access Token", example = "eyJhbGciOi...")
+        String accessToken,
+        @Schema(description = "JWT Refresh Token", example = "eyJhbGciOi...")
+        String refreshToken
+) {
+}

--- a/src/main/java/com/project/likelion14thbe/domain/auth/entity/Token.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/entity/Token.java
@@ -1,0 +1,31 @@
+package com.project.likelion14thbe.domain.auth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "token")
+public class Token {
+
+    @Id
+    @Column(name = "email", length = 100)
+    private String email;
+
+    @Column(name = "token", nullable = false, length = 500)
+    private String token;
+
+    public void updateToken(String newToken) {
+        this.token = newToken;
+    }
+}

--- a/src/main/java/com/project/likelion14thbe/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/exception/AuthErrorCode.java
@@ -1,0 +1,23 @@
+package com.project.likelion14thbe.domain.auth.exception;
+
+import com.project.likelion14thbe.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements BaseErrorCode {
+
+    WRONG_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH401_1", "이메일 또는 비밀번호가 잘못되었습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_2", "잘못된 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_3", "만료된 토큰입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH401_4", "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH403_1", "권한이 없습니다."),
+    MEMBER_NOT_FOUND_AUTH(HttpStatus.NOT_FOUND, "AUTH404_1", "계정을 찾을 수 없습니다."),
+    BODY_PARSE_ERROR(HttpStatus.BAD_REQUEST, "AUTH400_1", "Request Body 파싱 중 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/project/likelion14thbe/domain/auth/exception/AuthException.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/exception/AuthException.java
@@ -1,0 +1,12 @@
+package com.project.likelion14thbe.domain.auth.exception;
+
+import com.project.likelion14thbe.global.apiPayload.exception.CustomException;
+import lombok.Getter;
+
+@Getter
+public class AuthException extends CustomException {
+
+    public AuthException(AuthErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/project/likelion14thbe/domain/auth/repository/TokenRepository.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/repository/TokenRepository.java
@@ -1,0 +1,11 @@
+package com.project.likelion14thbe.domain.auth.repository;
+
+import com.project.likelion14thbe.domain.auth.entity.Token;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TokenRepository extends JpaRepository<Token, String> {
+
+    Optional<Token> findByEmail(String email);
+}

--- a/src/main/java/com/project/likelion14thbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/controller/MemberController.java
@@ -6,17 +6,17 @@ import com.project.likelion14thbe.domain.member.dto.response.MemberResDTO;
 import com.project.likelion14thbe.domain.member.service.command.MemberCommandService;
 import com.project.likelion14thbe.domain.member.service.query.MemberQueryService;
 import com.project.likelion14thbe.global.apiPayload.CustomResponse;
+import com.project.likelion14thbe.global.security.userdetails.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -37,27 +37,29 @@ public class MemberController implements MemberDocs {
     }
 
     @Override
-    @PatchMapping("/members/{memberId}/password")
+    @PatchMapping("/members/me/password")
     public CustomResponse<String> resetPassword(
-            @PathVariable Long memberId,
+            @AuthenticationPrincipal CustomUserDetails user,
             @RequestBody MemberReqDTO.PasswordResetDTO request
     ) {
-        memberCommandService.updatePassword(memberId, request);
+        memberCommandService.updatePassword(user.getUsername(), request);
         return CustomResponse.onSuccess("비밀번호 변경 성공");
     }
 
     @Override
-    @DeleteMapping("/members/{memberId}")
-    public CustomResponse<String> deleteMember(@PathVariable Long memberId) {
-        memberCommandService.deleteMember(memberId);
+    @DeleteMapping("/members/me")
+    public CustomResponse<String> deleteMember(
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        memberCommandService.deleteMember(user.getUsername());
         return CustomResponse.onSuccess("회원 탈퇴 성공");
     }
 
     @Override
     @GetMapping("/members/me")
     public CustomResponse<MemberResDTO.MyInfoResDTO> getMyInfo(
-            @RequestParam Long memberId
+            @AuthenticationPrincipal CustomUserDetails user
     ) {
-        return CustomResponse.onSuccess(HttpStatus.OK, "내 정보 조회 성공", memberQueryService.getMyInfo(memberId));
+        return CustomResponse.onSuccess(HttpStatus.OK, "내 정보 조회 성공", memberQueryService.getMyInfo(user.getUsername()));
     }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/controller/MemberController.java
@@ -37,14 +37,6 @@ public class MemberController implements MemberDocs {
     }
 
     @Override
-    @PostMapping("/auth/login")
-    public CustomResponse<MemberResDTO.LoginResDTO> login(
-            @Valid @RequestBody MemberReqDTO.LoginReqDTO request
-    ) {
-        return CustomResponse.onSuccess(HttpStatus.OK, "로그인 성공", memberCommandService.login(request));
-    }
-
-    @Override
     @PatchMapping("/members/{memberId}/password")
     public CustomResponse<String> resetPassword(
             @PathVariable Long memberId,

--- a/src/main/java/com/project/likelion14thbe/domain/member/controller/docs/MemberDocs.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/controller/docs/MemberDocs.java
@@ -3,8 +3,8 @@ package com.project.likelion14thbe.domain.member.controller.docs;
 import com.project.likelion14thbe.domain.member.dto.request.MemberReqDTO;
 import com.project.likelion14thbe.domain.member.dto.response.MemberResDTO;
 import com.project.likelion14thbe.global.apiPayload.CustomResponse;
+import com.project.likelion14thbe.global.security.userdetails.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -13,7 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "Member", description = "회원 API — 회원가입, 내 정보 조회, 비밀번호 수정, 회원 탈퇴 (로그인은 시큐리티 필터 /api/v1/login 으로 이동)")
+@Tag(name = "Member", description = "회원 API — 회원가입, 내 정보 조회, 비밀번호 수정, 회원 탈퇴")
 public interface MemberDocs {
 
     @Operation(
@@ -50,9 +50,10 @@ public interface MemberDocs {
     CustomResponse<MemberResDTO.SignUpResDTO> signUp(MemberReqDTO.SignUpReqDTO request);
 
     @Operation(
-            summary = "비밀번호 변경 (5주차 강의 PDF 단순 버전)",
-            description = "회원의 비밀번호를 변경한다. 시큐리티 미적용으로 memberId를 PathVariable로 임시 전달."
+            summary = "비밀번호 변경",
+            description = "로그인한 본인의 비밀번호를 변경한다. JWT의 subject(email)로 본인을 식별한다."
     )
+    @SecurityRequirement(name = "JWT TOKEN")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공",
                     content = @Content(schema = @Schema(implementation = CustomResponse.class),
@@ -64,55 +65,8 @@ public interface MemberDocs {
                                       "result": "비밀번호 변경 성공"
                                     }
                                     """))),
-            @ApiResponse(responseCode = "404", description = "회원 미존재",
-                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "isSuccess": false,
-                                      "code": "MEMBER404_1",
-                                      "message": "회원이 존재하지 않습니다.",
-                                      "result": null
-                                    }
-                                    """)))
-    })
-    CustomResponse<String> resetPassword(Long memberId, MemberReqDTO.PasswordResetDTO request);
-
-    @Operation(
-            summary = "회원 탈퇴 (soft delete)",
-            description = "회원을 soft delete 한다. Member.deletedAt 컬럼이 갱신되며 30일 후 스케줄러가 hard delete 시도."
-    )
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공",
-                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "isSuccess": true,
-                                      "code": "200",
-                                      "message": "OK",
-                                      "result": "회원 탈퇴 성공"
-                                    }
-                                    """))),
-            @ApiResponse(responseCode = "404", description = "회원 미존재",
-                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "isSuccess": false,
-                                      "code": "MEMBER404_1",
-                                      "message": "회원이 존재하지 않습니다.",
-                                      "result": null
-                                    }
-                                    """)))
-    })
-    CustomResponse<String> deleteMember(Long memberId);
-
-    @Operation(
-            summary = "내 정보 조회",
-            description = "현재 로그인한 회원의 정보를 조회한다. (JWT 적용 전까지 memberId는 임시 query 파라미터)"
-    )
-    @SecurityRequirement(name = "JWT TOKEN")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "내 정보 조회 성공",
-                    content = @Content(schema = @Schema(implementation = MemberResDTO.MyInfoResDTO.class))),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 없음·만료·위조",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class))),
             @ApiResponse(responseCode = "404", description = "회원 미존재 (탈퇴 등)",
                     content = @Content(schema = @Schema(implementation = CustomResponse.class),
                             examples = @ExampleObject(value = """
@@ -124,7 +78,59 @@ public interface MemberDocs {
                                     }
                                     """)))
     })
-    CustomResponse<MemberResDTO.MyInfoResDTO> getMyInfo(
-            @Parameter(description = "조회 회원 ID (JWT 적용 전 임시)", example = "1") Long memberId
-    );
+    CustomResponse<String> resetPassword(CustomUserDetails user, MemberReqDTO.PasswordResetDTO request);
+
+    @Operation(
+            summary = "회원 탈퇴 (soft delete)",
+            description = "로그인한 본인을 soft delete 한다. Member.deletedAt 컬럼이 갱신되며 30일 후 스케줄러가 hard delete 시도."
+    )
+    @SecurityRequirement(name = "JWT TOKEN")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "200",
+                                      "message": "OK",
+                                      "result": "회원 탈퇴 성공"
+                                    }
+                                    """))),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 없음·만료·위조",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class))),
+            @ApiResponse(responseCode = "404", description = "회원 미존재",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "MEMBER404_1",
+                                      "message": "회원이 존재하지 않습니다.",
+                                      "result": null
+                                    }
+                                    """)))
+    })
+    CustomResponse<String> deleteMember(CustomUserDetails user);
+
+    @Operation(
+            summary = "내 정보 조회",
+            description = "로그인한 본인의 정보를 조회한다."
+    )
+    @SecurityRequirement(name = "JWT TOKEN")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "내 정보 조회 성공",
+                    content = @Content(schema = @Schema(implementation = MemberResDTO.MyInfoResDTO.class))),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 없음·만료·위조",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class))),
+            @ApiResponse(responseCode = "404", description = "회원 미존재 (탈퇴 등)",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "MEMBER404_1",
+                                      "message": "회원이 존재하지 않습니다.",
+                                      "result": null
+                                    }
+                                    """)))
+    })
+    CustomResponse<MemberResDTO.MyInfoResDTO> getMyInfo(CustomUserDetails user);
 }

--- a/src/main/java/com/project/likelion14thbe/domain/member/controller/docs/MemberDocs.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/controller/docs/MemberDocs.java
@@ -13,7 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "Member", description = "회원 API — 회원가입, 로그인, 내 정보 조회, 비밀번호 수정, 회원 탈퇴")
+@Tag(name = "Member", description = "회원 API — 회원가입, 내 정보 조회, 비밀번호 수정, 회원 탈퇴 (로그인은 시큐리티 필터 /api/v1/login 으로 이동)")
 public interface MemberDocs {
 
     @Operation(
@@ -48,36 +48,6 @@ public interface MemberDocs {
                                     """)))
     })
     CustomResponse<MemberResDTO.SignUpResDTO> signUp(MemberReqDTO.SignUpReqDTO request);
-
-    @Operation(
-            summary = "일반 로그인",
-            description = "이메일·비밀번호로 로그인 후 JWT Access/Refresh 토큰을 발급한다. (현재 토큰 3개 필드는 dummy 상수 — 실제 발급은 jjwt 도입 시 service 내부에서 교체 예정)"
-    )
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "로그인 성공",
-                    content = @Content(schema = @Schema(implementation = MemberResDTO.LoginResDTO.class))),
-            @ApiResponse(responseCode = "401", description = "비밀번호 불일치",
-                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "isSuccess": false,
-                                      "code": "MEMBER401_1",
-                                      "message": "비밀번호가 일치하지 않습니다.",
-                                      "result": null
-                                    }
-                                    """))),
-            @ApiResponse(responseCode = "404", description = "회원 미존재",
-                    content = @Content(schema = @Schema(implementation = CustomResponse.class),
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "isSuccess": false,
-                                      "code": "MEMBER404_1",
-                                      "message": "회원이 존재하지 않습니다.",
-                                      "result": null
-                                    }
-                                    """)))
-    })
-    CustomResponse<MemberResDTO.LoginResDTO> login(MemberReqDTO.LoginReqDTO request);
 
     @Operation(
             summary = "비밀번호 변경 (5주차 강의 PDF 단순 버전)",

--- a/src/main/java/com/project/likelion14thbe/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/converter/MemberConverter.java
@@ -3,17 +3,19 @@ package com.project.likelion14thbe.domain.member.converter;
 import com.project.likelion14thbe.domain.member.dto.request.MemberReqDTO;
 import com.project.likelion14thbe.domain.member.dto.response.MemberResDTO;
 import com.project.likelion14thbe.domain.member.entity.Member;
+import com.project.likelion14thbe.domain.member.enums.Role;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberConverter {
 
-    public static Member toMember(MemberReqDTO.SignUpReqDTO request) {
+    public static Member toMember(MemberReqDTO.SignUpReqDTO request, String encodedPassword) {
         return Member.builder()
                 .email(request.email())
-                .password(request.password())
+                .password(encodedPassword)
                 .name(request.name())
+                .role(Role.ROLE_USER)
                 .build();
     }
 
@@ -32,21 +34,6 @@ public class MemberConverter {
                 member.getEmail(),
                 member.getName(),
                 member.getCreatedAt()
-        );
-    }
-
-    public static MemberResDTO.LoginResDTO toLoginResDTO(
-            Member member,
-            String accessToken,
-            String refreshToken,
-            Long expiresIn
-    ) {
-        return new MemberResDTO.LoginResDTO(
-                member.getId(),
-                member.getName(),
-                accessToken,
-                refreshToken,
-                expiresIn
         );
     }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/member/dto/response/MemberResDTO.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/dto/response/MemberResDTO.java
@@ -19,21 +19,6 @@ public class MemberResDTO {
     ) {
     }
 
-    @Schema(description = "일반 로그인 응답 DTO")
-    public record LoginResDTO(
-            @Schema(description = "회원 ID", example = "1")
-            Long memberId,
-            @Schema(description = "이름", example = "홍길동")
-            String name,
-            @Schema(description = "JWT Access Token", example = "eyJhbGciOi...")
-            String accessToken,
-            @Schema(description = "JWT Refresh Token", example = "eyJhbGciOi...")
-            String refreshToken,
-            @Schema(description = "Access Token 만료 시간(초)", example = "3600")
-            Long expiresIn
-    ) {
-    }
-
     @Schema(description = "비밀번호 수정 응답 DTO")
     public record UpdatePasswordResDTO(
             @Schema(description = "회원 ID", example = "1")

--- a/src/main/java/com/project/likelion14thbe/domain/member/entity/Member.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/entity/Member.java
@@ -1,8 +1,11 @@
 package com.project.likelion14thbe.domain.member.entity;
 
+import com.project.likelion14thbe.domain.member.enums.Role;
 import com.project.likelion14thbe.global.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -38,6 +41,11 @@ public class Member extends BaseEntity {
 
     @Column(name = "profile_image", length = 500)
     private String profileImage;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, length = 20)
+    @Builder.Default
+    private Role role = Role.ROLE_USER;
 
     // soft delete를 위한 필드 추가
     @Column(name = "deleted_at")

--- a/src/main/java/com/project/likelion14thbe/domain/member/enums/Role.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/enums/Role.java
@@ -1,0 +1,6 @@
+package com.project.likelion14thbe.domain.member.enums;
+
+public enum Role {
+    ROLE_USER,
+    ROLE_ADMIN
+}

--- a/src/main/java/com/project/likelion14thbe/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/repository/MemberRepository.java
@@ -19,6 +19,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Query("SELECT m FROM Member m WHERE m.id = :id AND m.deletedAt IS NULL")
     Optional<Member> findByIdAndNotDeleted(@Param("id") Long id);
 
+    @Query("SELECT m FROM Member m WHERE m.email = :email AND m.deletedAt IS NULL")
+    Optional<Member> findByEmailAndNotDeleted(@Param("email") String email);
+
     // 삭제된 회원 포함 조회 (스케줄러용)
     @Query("SELECT m FROM Member m WHERE m.deletedAt IS NOT NULL AND m.deletedAt < :threshold")
     List<Member> findAllDeletedBefore(@Param("threshold") LocalDateTime threshold);

--- a/src/main/java/com/project/likelion14thbe/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/repository/MemberRepository.java
@@ -15,6 +15,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByEmail(String email);
 
+    boolean existsByEmailAndDeletedAtIsNull(String email);
+
     // 삭제되지 않은 활성 회원 조회
     @Query("SELECT m FROM Member m WHERE m.id = :id AND m.deletedAt IS NULL")
     Optional<Member> findByIdAndNotDeleted(@Param("id") Long id);

--- a/src/main/java/com/project/likelion14thbe/domain/member/service/command/MemberCommandService.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/service/command/MemberCommandService.java
@@ -7,7 +7,7 @@ public interface MemberCommandService {
 
     MemberResDTO.SignUpResDTO signUp(MemberReqDTO.SignUpReqDTO request);
 
-    void updatePassword(Long memberId, MemberReqDTO.PasswordResetDTO dto);
+    void updatePassword(String email, MemberReqDTO.PasswordResetDTO dto);
 
-    void deleteMember(Long memberId);
+    void deleteMember(String email);
 }

--- a/src/main/java/com/project/likelion14thbe/domain/member/service/command/MemberCommandService.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/service/command/MemberCommandService.java
@@ -7,8 +7,6 @@ public interface MemberCommandService {
 
     MemberResDTO.SignUpResDTO signUp(MemberReqDTO.SignUpReqDTO request);
 
-    MemberResDTO.LoginResDTO login(MemberReqDTO.LoginReqDTO request);
-
     void updatePassword(Long memberId, MemberReqDTO.PasswordResetDTO dto);
 
     void deleteMember(Long memberId);

--- a/src/main/java/com/project/likelion14thbe/domain/member/service/command/MemberCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/service/command/MemberCommandServiceImpl.java
@@ -32,17 +32,16 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     }
 
     @Override
-    public void updatePassword(Long memberId, MemberReqDTO.PasswordResetDTO dto) {
-        // 회원 정보 조회
-        Member member = memberRepository.findByIdAndNotDeleted(memberId)
+    public void updatePassword(String email, MemberReqDTO.PasswordResetDTO dto) {
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         member.updatePassword(passwordEncoder.encode(dto.password()));
     }
 
     @Override
-    public void deleteMember(Long memberId) {
-        Member member = memberRepository.findByIdAndNotDeleted(memberId)
+    public void deleteMember(String email) {
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         member.softDelete();

--- a/src/main/java/com/project/likelion14thbe/domain/member/service/command/MemberCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/service/command/MemberCommandServiceImpl.java
@@ -8,6 +8,7 @@ import com.project.likelion14thbe.domain.member.exception.MemberErrorCode;
 import com.project.likelion14thbe.domain.member.exception.MemberException;
 import com.project.likelion14thbe.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,29 +18,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberCommandServiceImpl implements MemberCommandService {
 
     private final MemberRepository memberRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
 
     @Override
     public MemberResDTO.SignUpResDTO signUp(MemberReqDTO.SignUpReqDTO request) {
         if (memberRepository.existsByEmail(request.email())) {
             throw new MemberException(MemberErrorCode.MEMBER_EMAIL_DUPLICATE);
         }
-        Member member = MemberConverter.toMember(request);
+        String encodedPassword = passwordEncoder.encode(request.password());
+        Member member = MemberConverter.toMember(request, encodedPassword);
         Member saved = memberRepository.save(member);
         return MemberConverter.toSignUpResDTO(saved);
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public MemberResDTO.LoginResDTO login(MemberReqDTO.LoginReqDTO request) {
-        Member member = memberRepository.findByEmail(request.email())
-                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
-        if (!member.getPassword().equals(request.password())) {
-            throw new MemberException(MemberErrorCode.MEMBER_WRONG_PASSWORD);
-        }
-        String accessToken = "eyJhbGciOiJIUzI1NiJ9.dummy.access";
-        String refreshToken = "eyJhbGciOiJIUzI1NiJ9.dummy.refresh";
-        Long expiresIn = 3600L;
-        return MemberConverter.toLoginResDTO(member, accessToken, refreshToken, expiresIn);
     }
 
     @Override
@@ -48,7 +37,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         Member member = memberRepository.findByIdAndNotDeleted(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        member.updatePassword(dto.password());
+        member.updatePassword(passwordEncoder.encode(dto.password()));
     }
 
     @Override

--- a/src/main/java/com/project/likelion14thbe/domain/member/service/query/MemberQueryService.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/service/query/MemberQueryService.java
@@ -4,5 +4,5 @@ import com.project.likelion14thbe.domain.member.dto.response.MemberResDTO;
 
 public interface MemberQueryService {
 
-    MemberResDTO.MyInfoResDTO getMyInfo(Long memberId);
+    MemberResDTO.MyInfoResDTO getMyInfo(String email);
 }

--- a/src/main/java/com/project/likelion14thbe/domain/member/service/query/MemberQueryServiceImpl.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/service/query/MemberQueryServiceImpl.java
@@ -18,8 +18,8 @@ public class MemberQueryServiceImpl implements MemberQueryService {
     private final MemberRepository memberRepository;
 
     @Override
-    public MemberResDTO.MyInfoResDTO getMyInfo(Long memberId) {
-        Member member = memberRepository.findByIdAndNotDeleted(memberId)
+    public MemberResDTO.MyInfoResDTO getMyInfo(String email) {
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
         return MemberConverter.toMyInfoResDTO(member);
     }

--- a/src/main/java/com/project/likelion14thbe/domain/order/controller/OrderController.java
+++ b/src/main/java/com/project/likelion14thbe/domain/order/controller/OrderController.java
@@ -6,9 +6,11 @@ import com.project.likelion14thbe.domain.order.dto.response.OrderResDTO;
 import com.project.likelion14thbe.domain.order.service.command.OrderCommandService;
 import com.project.likelion14thbe.domain.order.service.query.OrderQueryService;
 import com.project.likelion14thbe.global.apiPayload.CustomResponse;
+import com.project.likelion14thbe.global.security.userdetails.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,30 +31,30 @@ public class OrderController implements OrderDocs {
     @Override
     @PostMapping("/orders")
     public CustomResponse<OrderResDTO.CreateOrderResDTO> createOrder(
-            @RequestParam Long memberId,
+            @AuthenticationPrincipal CustomUserDetails user,
             @Valid @RequestBody OrderReqDTO.CreateOrderReqDTO request
     ) {
-        OrderResDTO.CreateOrderResDTO body = orderCommandService.createOrder(memberId, request);
+        OrderResDTO.CreateOrderResDTO body = orderCommandService.createOrder(user.getUsername(), request);
         return CustomResponse.onSuccess(HttpStatus.CREATED, "주문 생성 성공", body);
     }
 
     @Override
     @GetMapping("/members/me/orders")
     public CustomResponse<OrderResDTO.MyOrderListResDTO> getMyOrders(
-            @RequestParam Long memberId,
+            @AuthenticationPrincipal CustomUserDetails user,
             @RequestParam(defaultValue = "0") Integer page,
             @RequestParam(defaultValue = "10") Integer size
     ) {
-        return CustomResponse.onSuccess(HttpStatus.OK, "내 주문 목록 조회 성공", orderQueryService.getMyOrders(memberId, page, size));
+        return CustomResponse.onSuccess(HttpStatus.OK, "내 주문 목록 조회 성공", orderQueryService.getMyOrders(user.getUsername(), page, size));
     }
 
     @Override
     @DeleteMapping("/orders/{orderId}")
     public CustomResponse<String> cancelOrder(
             @PathVariable Long orderId,
-            @RequestParam Long memberId
+            @AuthenticationPrincipal CustomUserDetails user
     ) {
-        orderCommandService.cancelOrder(orderId, memberId);
+        orderCommandService.cancelOrder(orderId, user.getUsername());
         return CustomResponse.onSuccess("주문 취소 성공");
     }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/order/controller/docs/OrderDocs.java
+++ b/src/main/java/com/project/likelion14thbe/domain/order/controller/docs/OrderDocs.java
@@ -3,6 +3,7 @@ package com.project.likelion14thbe.domain.order.controller.docs;
 import com.project.likelion14thbe.domain.order.dto.request.OrderReqDTO;
 import com.project.likelion14thbe.domain.order.dto.response.OrderResDTO;
 import com.project.likelion14thbe.global.apiPayload.CustomResponse;
+import com.project.likelion14thbe.global.security.userdetails.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -19,7 +20,7 @@ public interface OrderDocs {
 
     @Operation(
             summary = "주문 생성",
-            description = "현재 로그인한 회원이 특정 상품을 주문한다. (JWT 적용 전까지 memberId는 임시 query 파라미터)"
+            description = "현재 로그인한 회원이 특정 상품을 주문한다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "주문 생성 성공",
@@ -58,13 +59,13 @@ public interface OrderDocs {
                             }))
     })
     CustomResponse<OrderResDTO.CreateOrderResDTO> createOrder(
-            @Parameter(description = "주문자 회원 ID (JWT 적용 전 임시)", example = "1") Long memberId,
+            CustomUserDetails user,
             OrderReqDTO.CreateOrderReqDTO request
     );
 
     @Operation(
             summary = "내 주문 목록 조회",
-            description = "현재 로그인한 회원의 모든 주문을 페이징 조회한다. (JWT 적용 전까지 memberId는 임시 query 파라미터)"
+            description = "현재 로그인한 회원의 모든 주문을 페이징 조회한다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "내 주문 목록 조회 성공",
@@ -81,14 +82,14 @@ public interface OrderDocs {
                                     """)))
     })
     CustomResponse<OrderResDTO.MyOrderListResDTO> getMyOrders(
-            @Parameter(description = "조회 회원 ID (JWT 적용 전 임시)", example = "1") Long memberId,
+            CustomUserDetails user,
             @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") Integer page,
             @Parameter(description = "페이지당 개수", example = "10") Integer size
     );
 
     @Operation(
             summary = "주문 취소",
-            description = "본인의 주문을 취소(hard delete)한다. (JWT 적용 전까지 memberId는 임시 query 파라미터)"
+            description = "본인의 주문을 취소(hard delete)한다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "주문 취소 성공",
@@ -124,6 +125,6 @@ public interface OrderDocs {
     })
     CustomResponse<String> cancelOrder(
             @Parameter(description = "취소할 주문 ID", example = "1") Long orderId,
-            @Parameter(description = "요청 회원 ID (JWT 적용 전 임시)", example = "1") Long memberId
+            CustomUserDetails user
     );
 }

--- a/src/main/java/com/project/likelion14thbe/domain/order/service/command/OrderCommandService.java
+++ b/src/main/java/com/project/likelion14thbe/domain/order/service/command/OrderCommandService.java
@@ -5,7 +5,7 @@ import com.project.likelion14thbe.domain.order.dto.response.OrderResDTO;
 
 public interface OrderCommandService {
 
-    OrderResDTO.CreateOrderResDTO createOrder(Long memberId, OrderReqDTO.CreateOrderReqDTO request);
+    OrderResDTO.CreateOrderResDTO createOrder(String email, OrderReqDTO.CreateOrderReqDTO request);
 
-    void cancelOrder(Long orderId, Long memberId);
+    void cancelOrder(Long orderId, String email);
 }

--- a/src/main/java/com/project/likelion14thbe/domain/order/service/command/OrderCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion14thbe/domain/order/service/command/OrderCommandServiceImpl.java
@@ -25,8 +25,8 @@ public class OrderCommandServiceImpl implements OrderCommandService {
     private final ProductRepository productRepository;
 
     @Override
-    public OrderResDTO.CreateOrderResDTO createOrder(Long memberId, OrderReqDTO.CreateOrderReqDTO request) {
-        Member member = memberRepository.findByIdAndNotDeleted(memberId)
+    public OrderResDTO.CreateOrderResDTO createOrder(String email, OrderReqDTO.CreateOrderReqDTO request) {
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
                 .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_MEMBER_NOT_FOUND));
         Product product = productRepository.findById(request.productId())
                 .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_PRODUCT_NOT_FOUND));
@@ -38,12 +38,15 @@ public class OrderCommandServiceImpl implements OrderCommandService {
     }
 
     @Override
-    public void cancelOrder(Long orderId, Long memberId) {
+    public void cancelOrder(Long orderId, String email) {
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
+                .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_MEMBER_NOT_FOUND));
+
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
 
-        // 본인 주문 검증 (시큐리티 미적용으로 임시)
-        if (!order.getMember().getId().equals(memberId)) {
+        // 본인 주문 검증 — 인증 사용자(email로 조회) 기준
+        if (!order.getMember().getId().equals(member.getId())) {
             throw new OrderException(OrderErrorCode.ORDER_FORBIDDEN);
         }
 

--- a/src/main/java/com/project/likelion14thbe/domain/order/service/query/OrderQueryService.java
+++ b/src/main/java/com/project/likelion14thbe/domain/order/service/query/OrderQueryService.java
@@ -4,5 +4,5 @@ import com.project.likelion14thbe.domain.order.dto.response.OrderResDTO;
 
 public interface OrderQueryService {
 
-    OrderResDTO.MyOrderListResDTO getMyOrders(Long memberId, Integer page, Integer size);
+    OrderResDTO.MyOrderListResDTO getMyOrders(String email, Integer page, Integer size);
 }

--- a/src/main/java/com/project/likelion14thbe/domain/order/service/query/OrderQueryServiceImpl.java
+++ b/src/main/java/com/project/likelion14thbe/domain/order/service/query/OrderQueryServiceImpl.java
@@ -1,5 +1,6 @@
 package com.project.likelion14thbe.domain.order.service.query;
 
+import com.project.likelion14thbe.domain.member.entity.Member;
 import com.project.likelion14thbe.domain.member.repository.MemberRepository;
 import com.project.likelion14thbe.domain.order.converter.OrderConverter;
 import com.project.likelion14thbe.domain.order.dto.response.OrderResDTO;
@@ -23,12 +24,11 @@ public class OrderQueryServiceImpl implements OrderQueryService {
     private final MemberRepository memberRepository;
 
     @Override
-    public OrderResDTO.MyOrderListResDTO getMyOrders(Long memberId, Integer page, Integer size) {
-        if (memberRepository.findByIdAndNotDeleted(memberId).isEmpty()) {
-            throw new OrderException(OrderErrorCode.ORDER_MEMBER_NOT_FOUND);
-        }
+    public OrderResDTO.MyOrderListResDTO getMyOrders(String email, Integer page, Integer size) {
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
+                .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_MEMBER_NOT_FOUND));
         Pageable pageable = PageRequest.of(page, size);
-        Page<Order> orders = orderRepository.findAllByMember_IdOrderByCreatedAtDesc(memberId, pageable);
+        Page<Order> orders = orderRepository.findAllByMember_IdOrderByCreatedAtDesc(member.getId(), pageable);
         return OrderConverter.toMyOrderListResDTO(orders);
     }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/product/controller/ProductController.java
+++ b/src/main/java/com/project/likelion14thbe/domain/product/controller/ProductController.java
@@ -9,6 +9,7 @@ import com.project.likelion14thbe.global.apiPayload.CustomResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -47,6 +48,7 @@ public class ProductController implements ProductDocs {
     }
 
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping
     public CustomResponse<ProductResDTO.CreateProductResDTO> createProduct(
             @Valid @RequestBody ProductReqDTO.CreateProductReqDTO request
@@ -56,6 +58,7 @@ public class ProductController implements ProductDocs {
     }
 
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("/{productId}")
     public CustomResponse<ProductResDTO.UpdateProductResDTO> updateProduct(
             @PathVariable Long productId,
@@ -65,6 +68,7 @@ public class ProductController implements ProductDocs {
     }
 
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/{productId}")
     public CustomResponse<String> deleteProduct(
             @PathVariable Long productId

--- a/src/main/java/com/project/likelion14thbe/domain/product/controller/docs/ProductDocs.java
+++ b/src/main/java/com/project/likelion14thbe/domain/product/controller/docs/ProductDocs.java
@@ -54,8 +54,8 @@ public interface ProductDocs {
     );
 
     @Operation(
-            summary = "상품 추가",
-            description = "신규 상품을 등록한다. (6주차 시큐리티 도입 후 관리자 권한 검증 추가 예정)"
+            summary = "상품 추가 (ADMIN 전용)",
+            description = "신규 상품을 등록한다. ADMIN 권한이 필요합니다."
     )
     @SecurityRequirement(name = "JWT TOKEN")
     @ApiResponses({
@@ -80,9 +80,10 @@ public interface ProductDocs {
     );
 
     @Operation(
-            summary = "상품 수정",
+            summary = "상품 수정 (ADMIN 전용)",
             description = "특정 상품의 정보를 부분 수정한다. null 필드는 변경하지 않는다."
     )
+    @SecurityRequirement(name = "JWT TOKEN")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "상품 수정 성공",
                     content = @Content(schema = @Schema(implementation = CustomResponse.class),
@@ -128,8 +129,8 @@ public interface ProductDocs {
     );
 
     @Operation(
-            summary = "상품 삭제",
-            description = "특정 상품을 hard delete 한다. (6주차 시큐리티 도입 후 관리자 권한 검증 추가 예정)"
+            summary = "상품 삭제 (ADMIN 전용)",
+            description = "특정 상품을 hard delete 한다. ADMIN 권한이 필요합니다."
     )
     @SecurityRequirement(name = "JWT TOKEN")
     @ApiResponses({

--- a/src/main/java/com/project/likelion14thbe/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/controller/ReviewController.java
@@ -6,9 +6,11 @@ import com.project.likelion14thbe.domain.review.dto.response.ReviewResDTO;
 import com.project.likelion14thbe.domain.review.service.command.ReviewCommandService;
 import com.project.likelion14thbe.domain.review.service.query.ReviewQueryService;
 import com.project.likelion14thbe.global.apiPayload.CustomResponse;
+import com.project.likelion14thbe.global.security.userdetails.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -31,11 +33,11 @@ public class ReviewController implements ReviewDocs {
     @PostMapping("/products/{productId}/reviews")
     public CustomResponse<ReviewResDTO.CreateReviewResDTO> createReview(
             @PathVariable Long productId,
-            @RequestParam Long memberId,
+            @AuthenticationPrincipal CustomUserDetails user,
             @Valid @RequestBody ReviewReqDTO.CreateReviewReqDTO request
     ) {
         ReviewResDTO.CreateReviewResDTO body =
-                reviewCommandService.createReview(memberId, productId, request);
+                reviewCommandService.createReview(user.getUsername(), productId, request);
         return CustomResponse.onSuccess(HttpStatus.CREATED, "리뷰 작성 성공", body);
     }
 
@@ -64,11 +66,11 @@ public class ReviewController implements ReviewDocs {
     public CustomResponse<ReviewResDTO.UpdateReviewResDTO> updateReview(
             @PathVariable Long productId,
             @PathVariable Long reviewId,
-            @RequestParam Long memberId,
+            @AuthenticationPrincipal CustomUserDetails user,
             @Valid @RequestBody ReviewReqDTO.UpdateReviewReqDTO request
     ) {
         return CustomResponse.onSuccess(
-                reviewCommandService.updateReview(memberId, productId, reviewId, request)
+                reviewCommandService.updateReview(user.getUsername(), productId, reviewId, request)
         );
     }
 
@@ -77,19 +79,19 @@ public class ReviewController implements ReviewDocs {
     public CustomResponse<String> deleteReview(
             @PathVariable Long productId,
             @PathVariable Long reviewId,
-            @RequestParam Long memberId
+            @AuthenticationPrincipal CustomUserDetails user
     ) {
-        reviewCommandService.deleteReview(memberId, productId, reviewId);
+        reviewCommandService.deleteReview(user.getUsername(), productId, reviewId);
         return CustomResponse.onSuccess("리뷰 삭제 성공");
     }
 
     @Override
     @GetMapping("/members/me/reviews")
     public CustomResponse<ReviewResDTO.MyReviewListResDTO> getMyReviews(
-            @RequestParam Long memberId,
+            @AuthenticationPrincipal CustomUserDetails user,
             @RequestParam(defaultValue = "0") Integer page,
             @RequestParam(defaultValue = "10") Integer size
     ) {
-        return CustomResponse.onSuccess(HttpStatus.OK, "내 리뷰 목록 조회 성공", reviewQueryService.getMyReviews(memberId, page, size));
+        return CustomResponse.onSuccess(HttpStatus.OK, "내 리뷰 목록 조회 성공", reviewQueryService.getMyReviews(user.getUsername(), page, size));
     }
 }

--- a/src/main/java/com/project/likelion14thbe/domain/review/controller/docs/ReviewDocs.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/controller/docs/ReviewDocs.java
@@ -3,6 +3,7 @@ package com.project.likelion14thbe.domain.review.controller.docs;
 import com.project.likelion14thbe.domain.review.dto.request.ReviewReqDTO;
 import com.project.likelion14thbe.domain.review.dto.response.ReviewResDTO;
 import com.project.likelion14thbe.global.apiPayload.CustomResponse;
+import com.project.likelion14thbe.global.security.userdetails.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -19,7 +20,7 @@ public interface ReviewDocs {
 
     @Operation(
             summary = "리뷰 생성",
-            description = "특정 상품에 대해 새로운 리뷰를 생성한다. 동일 상품에 1인 1회 작성 제한. (JWT 적용 전까지 memberId는 임시 query 파라미터)"
+            description = "특정 상품에 대해 새로운 리뷰를 생성한다. 동일 상품에 1인 1회 작성 제한."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "리뷰 생성 성공",
@@ -70,7 +71,7 @@ public interface ReviewDocs {
     })
     CustomResponse<ReviewResDTO.CreateReviewResDTO> createReview(
             @Parameter(description = "상품 아이디", example = "5") Long productId,
-            @Parameter(description = "작성자 회원 ID (JWT 적용 전 임시)", example = "1") Long memberId,
+            CustomUserDetails user,
             ReviewReqDTO.CreateReviewReqDTO request
     );
 
@@ -135,7 +136,7 @@ public interface ReviewDocs {
 
     @Operation(
             summary = "리뷰 수정",
-            description = "본인이 작성한 리뷰의 별점/내용을 부분 수정한다. (JWT 적용 전까지 memberId는 임시 query 파라미터)"
+            description = "본인이 작성한 리뷰의 별점/내용을 부분 수정한다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "리뷰 수정 성공",
@@ -208,13 +209,13 @@ public interface ReviewDocs {
     CustomResponse<ReviewResDTO.UpdateReviewResDTO> updateReview(
             @Parameter(description = "상품 아이디", example = "5") Long productId,
             @Parameter(description = "리뷰 아이디", example = "123") Long reviewId,
-            @Parameter(description = "작성자 회원 ID (JWT 적용 전 임시)", example = "1") Long memberId,
+            CustomUserDetails user,
             ReviewReqDTO.UpdateReviewReqDTO request
     );
 
     @Operation(
             summary = "리뷰 삭제",
-            description = "본인이 작성한 리뷰를 hard delete 한다. (JWT 적용 전까지 memberId는 임시 query 파라미터)"
+            description = "본인이 작성한 리뷰를 hard delete 한다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "리뷰 삭제 성공",
@@ -269,12 +270,12 @@ public interface ReviewDocs {
     CustomResponse<String> deleteReview(
             @Parameter(description = "상품 아이디", example = "5") Long productId,
             @Parameter(description = "리뷰 아이디", example = "123") Long reviewId,
-            @Parameter(description = "작성자 회원 ID (JWT 적용 전 임시)", example = "1") Long memberId
+            CustomUserDetails user
     );
 
     @Operation(
             summary = "내 리뷰 조회",
-            description = "현재 로그인한 회원이 작성한 모든 리뷰를 페이징 조회한다. (JWT 적용 전까지 memberId는 임시 query 파라미터)"
+            description = "현재 로그인한 회원이 작성한 모든 리뷰를 페이징 조회한다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "내 리뷰 조회 성공",
@@ -291,7 +292,7 @@ public interface ReviewDocs {
                                     """)))
     })
     CustomResponse<ReviewResDTO.MyReviewListResDTO> getMyReviews(
-            @Parameter(description = "조회 회원 ID (JWT 적용 전 임시)", example = "1") Long memberId,
+            CustomUserDetails user,
             @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") Integer page,
             @Parameter(description = "페이지당 개수", example = "10") Integer size
     );

--- a/src/main/java/com/project/likelion14thbe/domain/review/service/command/ReviewCommandService.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/service/command/ReviewCommandService.java
@@ -6,17 +6,17 @@ import com.project.likelion14thbe.domain.review.dto.response.ReviewResDTO;
 public interface ReviewCommandService {
 
     ReviewResDTO.CreateReviewResDTO createReview(
-            Long memberId,
+            String email,
             Long productId,
             ReviewReqDTO.CreateReviewReqDTO request
     );
 
     ReviewResDTO.UpdateReviewResDTO updateReview(
-            Long memberId,
+            String email,
             Long productId,
             Long reviewId,
             ReviewReqDTO.UpdateReviewReqDTO request
     );
 
-    void deleteReview(Long memberId, Long productId, Long reviewId);
+    void deleteReview(String email, Long productId, Long reviewId);
 }

--- a/src/main/java/com/project/likelion14thbe/domain/review/service/command/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/service/command/ReviewCommandServiceImpl.java
@@ -26,16 +26,16 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
 
     @Override
     public ReviewResDTO.CreateReviewResDTO createReview(
-            Long memberId,
+            String email,
             Long productId,
             ReviewReqDTO.CreateReviewReqDTO request
     ) {
-        Member member = memberRepository.findByIdAndNotDeleted(memberId)
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
                 .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_MEMBER_NOT_FOUND));
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_PRODUCT_NOT_FOUND));
 
-        if (reviewRepository.existsByMember_IdAndProduct_Id(memberId, productId)) {
+        if (reviewRepository.existsByMember_IdAndProduct_Id(member.getId(), productId)) {
             throw new ReviewException(ReviewErrorCode.REVIEW_ALREADY_EXISTS);
         }
 
@@ -46,15 +46,13 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
 
     @Override
     public ReviewResDTO.UpdateReviewResDTO updateReview(
-            Long memberId,
+            String email,
             Long productId,
             Long reviewId,
             ReviewReqDTO.UpdateReviewReqDTO request
     ) {
-        // 작성자 회원 검증 (탈퇴 회원은 수정 불가)
-        if (memberRepository.findByIdAndNotDeleted(memberId).isEmpty()) {
-            throw new ReviewException(ReviewErrorCode.REVIEW_MEMBER_NOT_FOUND);
-        }
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
+                .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_MEMBER_NOT_FOUND));
 
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND));
@@ -64,8 +62,8 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
             throw new ReviewException(ReviewErrorCode.REVIEW_NOT_BELONG_TO_PRODUCT);
         }
 
-        // 본인 리뷰 검증 (시큐리티 미적용으로 임시)
-        if (!review.getMember().getId().equals(memberId)) {
+        // 본인 리뷰 검증 — 인증 사용자(email로 조회) 기준
+        if (!review.getMember().getId().equals(member.getId())) {
             throw new ReviewException(ReviewErrorCode.REVIEW_FORBIDDEN);
         }
 
@@ -74,10 +72,9 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
     }
 
     @Override
-    public void deleteReview(Long memberId, Long productId, Long reviewId) {
-        if (memberRepository.findByIdAndNotDeleted(memberId).isEmpty()) {
-            throw new ReviewException(ReviewErrorCode.REVIEW_MEMBER_NOT_FOUND);
-        }
+    public void deleteReview(String email, Long productId, Long reviewId) {
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
+                .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_MEMBER_NOT_FOUND));
 
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND));
@@ -86,7 +83,7 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
             throw new ReviewException(ReviewErrorCode.REVIEW_NOT_BELONG_TO_PRODUCT);
         }
 
-        if (!review.getMember().getId().equals(memberId)) {
+        if (!review.getMember().getId().equals(member.getId())) {
             throw new ReviewException(ReviewErrorCode.REVIEW_FORBIDDEN);
         }
 

--- a/src/main/java/com/project/likelion14thbe/domain/review/service/query/ReviewQueryService.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/service/query/ReviewQueryService.java
@@ -8,5 +8,5 @@ public interface ReviewQueryService {
 
     ReviewResDTO.ReviewListResDTO getReviewList(Long productId, Integer page, Integer size, String sort);
 
-    ReviewResDTO.MyReviewListResDTO getMyReviews(Long memberId, Integer page, Integer size);
+    ReviewResDTO.MyReviewListResDTO getMyReviews(String email, Integer page, Integer size);
 }

--- a/src/main/java/com/project/likelion14thbe/domain/review/service/query/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/project/likelion14thbe/domain/review/service/query/ReviewQueryServiceImpl.java
@@ -1,5 +1,6 @@
 package com.project.likelion14thbe.domain.review.service.query;
 
+import com.project.likelion14thbe.domain.member.entity.Member;
 import com.project.likelion14thbe.domain.member.repository.MemberRepository;
 import com.project.likelion14thbe.domain.product.repository.ProductRepository;
 import com.project.likelion14thbe.domain.review.converter.ReviewConverter;
@@ -49,12 +50,11 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
     }
 
     @Override
-    public ReviewResDTO.MyReviewListResDTO getMyReviews(Long memberId, Integer page, Integer size) {
-        if (memberRepository.findByIdAndNotDeleted(memberId).isEmpty()) {
-            throw new ReviewException(ReviewErrorCode.REVIEW_MEMBER_NOT_FOUND);
-        }
+    public ReviewResDTO.MyReviewListResDTO getMyReviews(String email, Integer page, Integer size) {
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
+                .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_MEMBER_NOT_FOUND));
         Pageable pageable = PageRequest.of(page, size);
-        Page<Review> reviews = reviewRepository.findAllByMember_IdOrderByCreatedAtDesc(memberId, pageable);
+        Page<Review> reviews = reviewRepository.findAllByMember_IdOrderByCreatedAtDesc(member.getId(), pageable);
         return ReviewConverter.toMyReviewListResDTO(reviews);
     }
 }

--- a/src/main/java/com/project/likelion14thbe/global/apiPayload/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/likelion14thbe/global/apiPayload/exception/handler/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import com.project.likelion14thbe.global.apiPayload.exception.CustomException;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -100,6 +101,16 @@ public class GlobalExceptionHandler {
     public ResponseEntity<CustomResponse<Void>> handleMethodNotSupported(HttpRequestMethodNotSupportedException ex) {
         log.warn("[ HttpRequestMethodNotSupportedException ]: {}", ex.getMessage());
         BaseErrorCode errorCode = GeneralErrorCode.METHOD_NOT_ALLOWED_405;
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(CustomResponse.onFailure(errorCode.getCode(), errorCode.getMessage(), null));
+    }
+
+    // 메서드 보안(@PreAuthorize) 거부 — 권한 없음(403)으로 변환. 필터 단계 거부는 JwtAccessDeniedHandler가 처리하고,
+    // 컨트롤러 메서드 단계 거부는 여기로 올라오므로 500으로 새지 않도록 분리한다.
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<CustomResponse<Void>> handleAccessDenied(AccessDeniedException ex) {
+        log.warn("[ AccessDeniedException ]: {}", ex.getMessage());
+        BaseErrorCode errorCode = GeneralErrorCode.FORBIDDEN_403;
         return ResponseEntity.status(errorCode.getHttpStatus())
                 .body(CustomResponse.onFailure(errorCode.getCode(), errorCode.getMessage(), null));
     }

--- a/src/main/java/com/project/likelion14thbe/global/config/DataInitializer.java
+++ b/src/main/java/com/project/likelion14thbe/global/config/DataInitializer.java
@@ -1,0 +1,41 @@
+package com.project.likelion14thbe.global.config;
+
+import com.project.likelion14thbe.domain.member.entity.Member;
+import com.project.likelion14thbe.domain.member.enums.Role;
+import com.project.likelion14thbe.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DataInitializer implements CommandLineRunner {
+
+    private static final String ADMIN_EMAIL = "admin@likelion.com";
+    private static final String ADMIN_PASSWORD = "admin1234!";
+    private static final String ADMIN_NAME = "관리자";
+
+    private final MemberRepository memberRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional
+    public void run(String... args) {
+        if (memberRepository.existsByEmailAndDeletedAtIsNull(ADMIN_EMAIL)) {
+            log.info("ADMIN seed skip: {} already exists", ADMIN_EMAIL);
+            return;
+        }
+        Member admin = Member.builder()
+                .name(ADMIN_NAME)
+                .email(ADMIN_EMAIL)
+                .password(passwordEncoder.encode(ADMIN_PASSWORD))
+                .role(Role.ROLE_ADMIN)
+                .build();
+        memberRepository.save(admin);
+        log.info("ADMIN seed created: {}", ADMIN_EMAIL);
+    }
+}

--- a/src/main/java/com/project/likelion14thbe/global/security/config/CorsConfig.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/config/CorsConfig.java
@@ -1,0 +1,46 @@
+package com.project.likelion14thbe.global.security.config;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CorsConfig implements WebMvcConfigurer {
+
+    public static CorsConfigurationSource apiConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        ArrayList<String> allowedOriginPatterns = new ArrayList<>();
+        allowedOriginPatterns.add("http://localhost:8080");
+        allowedOriginPatterns.add("http://localhost:8081");
+        allowedOriginPatterns.add("http://localhost:3000");
+        allowedOriginPatterns.add("http://127.0.0.1:8080");
+        allowedOriginPatterns.add("http://127.0.0.1:8081");
+        allowedOriginPatterns.add("http://127.0.0.1:3000");
+
+        ArrayList<String> allowedHttpMethods = new ArrayList<>();
+        allowedHttpMethods.add("GET");
+        allowedHttpMethods.add("POST");
+        allowedHttpMethods.add("PUT");
+        allowedHttpMethods.add("PATCH");
+        allowedHttpMethods.add("DELETE");
+        allowedHttpMethods.add("OPTIONS");
+
+        configuration.setAllowedOrigins(allowedOriginPatterns);
+        configuration.setAllowedMethods(allowedHttpMethods);
+        configuration.setAllowedHeaders(List.of(HttpHeaders.AUTHORIZATION, HttpHeaders.CONTENT_TYPE));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+}

--- a/src/main/java/com/project/likelion14thbe/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/config/SecurityConfig.java
@@ -16,6 +16,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -27,6 +28,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/java/com/project/likelion14thbe/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/config/SecurityConfig.java
@@ -1,0 +1,78 @@
+package com.project.likelion14thbe.global.security.config;
+
+import com.project.likelion14thbe.global.security.filter.CustomLoginFilter;
+import com.project.likelion14thbe.global.security.filter.JwtAuthorizationFilter;
+import com.project.likelion14thbe.global.security.handler.JwtAccessDeniedHandler;
+import com.project.likelion14thbe.global.security.handler.JwtAuthenticationEntryPoint;
+import com.project.likelion14thbe.global.security.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final JwtUtil jwtUtil;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    // 인증 없이 접근 허용할 URL
+    private final String[] allowUrl = {
+            "/api/v1/login",                 // CustomLoginFilter 처리
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/swagger-resources/**",
+            "/webjars/**"
+    };
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        CustomLoginFilter loginFilter =
+                new CustomLoginFilter(authenticationManager(authenticationConfiguration), jwtUtil);
+        loginFilter.setFilterProcessesUrl("/api/v1/login");
+
+        http
+                .cors(cors -> cors.configurationSource(CorsConfig.apiConfigurationSource()))
+                .authorizeHttpRequests(req -> req
+                        .requestMatchers(allowUrl).permitAll()
+                        // 회원가입 (POST /api/v1/members) — 인증 없이 허용
+                        .requestMatchers(HttpMethod.POST, "/api/v1/members").permitAll()
+                        // 그 외는 인증 필수
+                        .anyRequest().authenticated())
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(new JwtAuthorizationFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
+                .addFilterAt(loginFilter, UsernamePasswordAuthenticationFilter.class)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(HttpBasicConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .exceptionHandling(eh -> eh
+                        .accessDeniedHandler(jwtAccessDeniedHandler)
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint));
+
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/project/likelion14thbe/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/config/SecurityConfig.java
@@ -33,7 +33,9 @@ public class SecurityConfig {
     // 인증 없이 접근 허용할 URL
     private final String[] allowUrl = {
             "/api/v1/login",                 // CustomLoginFilter 처리
+            "/swagger-ui.html",
             "/swagger-ui/**",
+            "/v3/api-docs",
             "/v3/api-docs/**",
             "/swagger-resources/**",
             "/webjars/**"

--- a/src/main/java/com/project/likelion14thbe/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/config/SecurityConfig.java
@@ -1,7 +1,10 @@
 package com.project.likelion14thbe.global.security.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.likelion14thbe.global.apiPayload.CustomResponse;
 import com.project.likelion14thbe.global.security.filter.CustomLoginFilter;
 import com.project.likelion14thbe.global.security.filter.JwtAuthorizationFilter;
+import com.project.likelion14thbe.global.security.handler.CustomLogoutHandler;
 import com.project.likelion14thbe.global.security.handler.JwtAccessDeniedHandler;
 import com.project.likelion14thbe.global.security.handler.JwtAuthenticationEntryPoint;
 import com.project.likelion14thbe.global.security.jwt.JwtUtil;
@@ -9,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -29,6 +34,7 @@ public class SecurityConfig {
     private final JwtUtil jwtUtil;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final CustomLogoutHandler customLogoutHandler;
 
     // 인증 없이 접근 허용할 URL
     private final String[] allowUrl = {
@@ -61,6 +67,19 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(HttpBasicConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
+                .logout(logout -> logout
+                        .logoutUrl("/api/v1/auth/logout")
+                        .addLogoutHandler(customLogoutHandler)
+                        .logoutSuccessHandler((req, res, auth) -> {
+                            res.setStatus(HttpStatus.OK.value());
+                            res.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                            res.setCharacterEncoding("UTF-8");
+                            res.getWriter().write(
+                                    new ObjectMapper().writeValueAsString(
+                                            CustomResponse.onSuccess("로그아웃 성공")
+                                    )
+                            );
+                        }))
                 .exceptionHandling(eh -> eh
                         .accessDeniedHandler(jwtAccessDeniedHandler)
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint));

--- a/src/main/java/com/project/likelion14thbe/global/security/filter/CustomLoginFilter.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/filter/CustomLoginFilter.java
@@ -1,0 +1,124 @@
+package com.project.likelion14thbe.global.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.likelion14thbe.domain.auth.dto.response.JwtDTO;
+import com.project.likelion14thbe.domain.auth.exception.AuthErrorCode;
+import com.project.likelion14thbe.domain.member.dto.request.MemberReqDTO;
+import com.project.likelion14thbe.global.apiPayload.CustomResponse;
+import com.project.likelion14thbe.global.security.jwt.JwtUtil;
+import com.project.likelion14thbe.global.security.userdetails.CustomUserDetails;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.authentication.LockedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final AuthenticationManager authenticationManager;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public Authentication attemptAuthentication(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response
+    ) throws AuthenticationException {
+
+        log.info("[ Login Filter ]  로그인 시도 : Custom Login Filter 작동 ");
+        ObjectMapper objectMapper = new ObjectMapper();
+        MemberReqDTO.LoginReqDTO requestBody;
+        try {
+            requestBody = objectMapper.readValue(request.getInputStream(), MemberReqDTO.LoginReqDTO.class);
+        } catch (IOException e) {
+            throw new AuthenticationServiceException("Request Body 파싱 중 오류");
+        }
+
+        String email = requestBody.email();
+        String password = requestBody.password();
+        log.info("[ Login Filter ]  Email ---> {} ", email);
+
+        UsernamePasswordAuthenticationToken authToken =
+                new UsernamePasswordAuthenticationToken(email, password, null);
+
+        return authenticationManager.authenticate(authToken);
+    }
+
+    @Override
+    protected void successfulAuthentication(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain chain,
+            @NonNull Authentication authentication
+    ) throws IOException {
+
+        log.info("[ Login Filter ] 로그인에 성공 하였습니다.");
+
+        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+
+        JwtDTO jwtDto = JwtDTO.builder()
+                .accessToken(jwtUtil.createJwtAccessToken(customUserDetails))
+                .refreshToken(jwtUtil.createJwtRefreshToken(customUserDetails))
+                .build();
+
+        CustomResponse<JwtDTO> responseBody = CustomResponse.onSuccess(jwtDto);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.setStatus(HttpStatus.OK.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(responseBody));
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull AuthenticationException failed
+    ) throws IOException {
+
+        log.info("[ Login Filter ] 로그인에 실패하였습니다. ({}) ", failed.getClass().getSimpleName());
+
+        AuthErrorCode errorCode;
+
+        if (failed instanceof BadCredentialsException) {
+            errorCode = AuthErrorCode.WRONG_CREDENTIALS;
+        } else if (failed instanceof LockedException || failed instanceof DisabledException) {
+            errorCode = AuthErrorCode.FORBIDDEN;
+        } else if (failed instanceof UsernameNotFoundException) {
+            errorCode = AuthErrorCode.MEMBER_NOT_FOUND_AUTH;
+        } else if (failed instanceof AuthenticationServiceException) {
+            errorCode = AuthErrorCode.BODY_PARSE_ERROR;
+        } else {
+            errorCode = AuthErrorCode.UNAUTHORIZED;
+        }
+
+        CustomResponse<Object> responseBody = CustomResponse.onFailure(
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                null
+        );
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(responseBody));
+    }
+}

--- a/src/main/java/com/project/likelion14thbe/global/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/filter/JwtAuthorizationFilter.java
@@ -1,0 +1,81 @@
+package com.project.likelion14thbe.global.security.filter;
+
+import com.project.likelion14thbe.domain.member.enums.Role;
+import com.project.likelion14thbe.global.security.jwt.JwtUtil;
+import com.project.likelion14thbe.global.security.userdetails.CustomUserDetails;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+        log.info("[ JwtAuthorizationFilter ] 인가 필터 작동");
+
+        try {
+            String accessToken = jwtUtil.resolveAccessToken(request);
+
+            if (accessToken == null) {
+                log.info("[ JwtAuthorizationFilter ] Access Token 없음, 다음 필터로 진행");
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            authenticateAccessToken(accessToken);
+            log.info("[ JwtAuthorizationFilter ] 종료. 다음 필터로 넘어갑니다.");
+            filterChain.doFilter(request, response);
+
+        } catch (ExpiredJwtException e) {
+            logger.warn("[ JwtAuthorizationFilter ] accessToken 이 만료되었습니다.");
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter().write("Access Token 이 만료되었습니다.");
+        } catch (SecurityException e) {
+            logger.warn("[ JwtAuthorizationFilter ] 잘못된 토큰입니다.");
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter().write("잘못된 토큰입니다.");
+        }
+    }
+
+    private void authenticateAccessToken(String accessToken) {
+        log.info("[ JwtAuthorizationFilter ] 토큰으로 인가 과정을 시작합니다.");
+
+        jwtUtil.validateToken(accessToken);
+        log.info("[ JwtAuthorizationFilter ] Access Token 유효성 검증 성공.");
+
+        String email = jwtUtil.getEmail(accessToken);
+        Role role = jwtUtil.getRoles(accessToken);
+
+        CustomUserDetails customUserDetails = new CustomUserDetails(email, null, role);
+        log.info("[ JwtAuthorizationFilter ] UserDetails 객체 생성 성공");
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                customUserDetails, null, customUserDetails.getAuthorities()
+        );
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        log.info("[ JwtAuthorizationFilter ] 인증 객체 저장 완료");
+    }
+}

--- a/src/main/java/com/project/likelion14thbe/global/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/filter/JwtAuthorizationFilter.java
@@ -1,8 +1,10 @@
 package com.project.likelion14thbe.global.security.filter;
 
+import com.project.likelion14thbe.domain.auth.exception.AuthErrorCode;
 import com.project.likelion14thbe.domain.member.enums.Role;
 import com.project.likelion14thbe.global.security.jwt.JwtUtil;
 import com.project.likelion14thbe.global.security.userdetails.CustomUserDetails;
+import com.project.likelion14thbe.global.security.utils.HttpResponseUtil;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -11,7 +13,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -48,14 +49,10 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
         } catch (ExpiredJwtException e) {
             logger.warn("[ JwtAuthorizationFilter ] accessToken 이 만료되었습니다.");
-            response.setStatus(HttpStatus.UNAUTHORIZED.value());
-            response.setCharacterEncoding("UTF-8");
-            response.getWriter().write("Access Token 이 만료되었습니다.");
+            HttpResponseUtil.setErrorResponse(response, AuthErrorCode.EXPIRED_TOKEN);
         } catch (SecurityException e) {
             logger.warn("[ JwtAuthorizationFilter ] 잘못된 토큰입니다.");
-            response.setStatus(HttpStatus.UNAUTHORIZED.value());
-            response.setCharacterEncoding("UTF-8");
-            response.getWriter().write("잘못된 토큰입니다.");
+            HttpResponseUtil.setErrorResponse(response, AuthErrorCode.INVALID_TOKEN);
         }
     }
 

--- a/src/main/java/com/project/likelion14thbe/global/security/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/handler/CustomLogoutHandler.java
@@ -1,0 +1,43 @@
+package com.project.likelion14thbe.global.security.handler;
+
+import com.project.likelion14thbe.domain.auth.repository.TokenRepository;
+import com.project.likelion14thbe.global.security.jwt.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomLogoutHandler implements LogoutHandler {
+
+    private final JwtUtil jwtUtil;
+    private final TokenRepository tokenRepository;
+
+    @Override
+    public void logout(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication
+    ) {
+        log.info("[ Logout Handler ] 로그아웃 처리 시작");
+
+        String accessToken = jwtUtil.resolveAccessToken(request);
+        if (accessToken == null) {
+            log.warn("[ Logout Handler ] Access Token이 없어 처리를 종료합니다.");
+            return;
+        }
+
+        try {
+            String email = jwtUtil.getEmail(accessToken);
+            tokenRepository.deleteById(email);
+            log.info("[ Logout Handler ] Refresh Token 삭제 완료 : {}", email);
+        } catch (Exception e) {
+            log.warn("[ Logout Handler ] Refresh Token 삭제 실패 : {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/project/likelion14thbe/global/security/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/handler/JwtAccessDeniedHandler.java
@@ -1,0 +1,36 @@
+package com.project.likelion14thbe.global.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.likelion14thbe.domain.auth.exception.AuthErrorCode;
+import com.project.likelion14thbe.global.apiPayload.CustomResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+
+        CustomResponse<Object> errorResponse = CustomResponse.onFailure(
+                AuthErrorCode.FORBIDDEN.getCode(),
+                AuthErrorCode.FORBIDDEN.getMessage(),
+                null
+        );
+        new ObjectMapper().writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/src/main/java/com/project/likelion14thbe/global/security/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/handler/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,36 @@
+package com.project.likelion14thbe.global.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.likelion14thbe.domain.auth.exception.AuthErrorCode;
+import com.project.likelion14thbe.global.apiPayload.CustomResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+
+        CustomResponse<Object> errorResponse = CustomResponse.onFailure(
+                AuthErrorCode.UNAUTHORIZED.getCode(),
+                AuthErrorCode.UNAUTHORIZED.getMessage(),
+                null
+        );
+        new ObjectMapper().writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/src/main/java/com/project/likelion14thbe/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/jwt/JwtUtil.java
@@ -1,0 +1,160 @@
+package com.project.likelion14thbe.global.security.jwt;
+
+import com.project.likelion14thbe.domain.auth.entity.Token;
+import com.project.likelion14thbe.domain.auth.repository.TokenRepository;
+import com.project.likelion14thbe.domain.member.enums.Role;
+import com.project.likelion14thbe.global.security.userdetails.CustomUserDetails;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class JwtUtil {
+
+    private final SecretKey secretKey;
+    private final Long accessExpMs;
+    private final Long refreshExpMs;
+    private final TokenRepository tokenRepository;
+
+    public JwtUtil(
+            @Value("${spring.jwt.secret:dGhpc2lzYWxvbmdlbm91Z2hzZWNyZXRrZXlmb3JqdzI1NmFsZ29yaXRobTEyMzQ1Njc4OTA=}") String secret,
+            @Value("${spring.jwt.token.access-expiration-time:1800000}") Long access,
+            @Value("${spring.jwt.token.refresh-expiration-time:1209600000}") Long refresh,
+            TokenRepository tokenRepository
+    ) {
+        this.secretKey = new SecretKeySpec(
+                secret.getBytes(StandardCharsets.UTF_8),
+                Jwts.SIG.HS256.key().build().getAlgorithm()
+        );
+        this.accessExpMs = access;
+        this.refreshExpMs = refresh;
+        this.tokenRepository = tokenRepository;
+    }
+
+    // JWT 토큰을 입력으로 받아 subject(email)을 추출
+    public String getEmail(String token) {
+        log.info("[ JwtUtil ] 토큰에서 이메일을 추출합니다.");
+        try {
+            return Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .getSubject();
+        } catch (Exception e) {
+            throw new SecurityException("잘못된 토큰입니다.");
+        }
+    }
+
+    // JWT 토큰에서 사용자 권한(role) 추출
+    public Role getRoles(String token) {
+        log.info("[ JwtUtil ] 토큰에서 권한을 추출합니다.");
+        try {
+            String roleStr = Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .get("role", String.class);
+            return Role.valueOf(roleStr);
+        } catch (Exception e) {
+            throw new SecurityException("잘못된 토큰입니다.");
+        }
+    }
+
+    // 토큰 발급 메서드 (subject = email, claim "role" = ROLE_USER 등)
+    public String tokenProvider(CustomUserDetails customUserDetails, Instant expiration) {
+        log.info("[ JwtUtil ] 토큰을 새로 생성합니다.");
+        Instant issuedAt = Instant.now();
+
+        String authorities = customUserDetails.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        return Jwts.builder()
+                .header()
+                .add("typ", "JWT")
+                .and()
+                .subject(customUserDetails.getUsername())
+                .claim("role", authorities)
+                .issuedAt(Date.from(issuedAt))
+                .expiration(Date.from(expiration))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    // Access Token 발급
+    public String createJwtAccessToken(CustomUserDetails customUserDetails) {
+        Instant expiration = Instant.now().plusMillis(accessExpMs);
+        return tokenProvider(customUserDetails, expiration);
+    }
+
+    // Refresh Token 발급 + DB 저장
+    public String createJwtRefreshToken(CustomUserDetails customUserDetails) {
+        Instant expiration = Instant.now().plusMillis(refreshExpMs);
+        String refreshToken = tokenProvider(customUserDetails, expiration);
+
+        String email = customUserDetails.getUsername();
+        tokenRepository.findByEmail(email)
+                .ifPresentOrElse(
+                        existing -> existing.updateToken(refreshToken),
+                        () -> tokenRepository.save(Token.builder()
+                                .email(email)
+                                .token(refreshToken)
+                                .build())
+                );
+
+        return refreshToken;
+    }
+
+    // HTTP 요청의 Authorization 헤더에서 Bearer 토큰 추출
+    public String resolveAccessToken(HttpServletRequest request) {
+        log.info("[ JwtUtil ] 헤더에서 토큰을 추출합니다.");
+        String tokenFromHeader = request.getHeader("Authorization");
+
+        if (tokenFromHeader == null || !tokenFromHeader.startsWith("Bearer ")) {
+            log.warn("[ JwtUtil ] Request Header 에 토큰이 존재하지 않습니다.");
+            return null;
+        }
+        return tokenFromHeader.split(" ")[1];
+    }
+
+    // 토큰 유효성 검증 (서명 + 만료)
+    public void validateToken(String token) {
+        log.info("[ JwtUtil ] 토큰의 유효성을 검증합니다.");
+        try {
+            // 시스템 시계 오차 3분 허용
+            long seconds = 3 * 60;
+            boolean isExpired = Jwts.parser()
+                    .clockSkewSeconds(seconds)
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .getExpiration()
+                    .before(new Date());
+            if (isExpired) {
+                log.info("만료된 JWT 토큰입니다.");
+            }
+        } catch (SecurityException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+            throw new SecurityException("잘못된 토큰입니다.");
+        } catch (ExpiredJwtException e) {
+            throw new ExpiredJwtException(null, null, "만료된 JWT 토큰입니다.");
+        }
+    }
+}

--- a/src/main/java/com/project/likelion14thbe/global/security/userdetails/CustomUserDetails.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/userdetails/CustomUserDetails.java
@@ -1,0 +1,57 @@
+package com.project.likelion14thbe.global.security.userdetails;
+
+import com.project.likelion14thbe.domain.member.enums.Role;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class CustomUserDetails implements UserDetails {
+
+    private final String email;
+    private final String password;
+    private final Role role;
+
+    public CustomUserDetails(String email, String password, Role role) {
+        this.email = email;
+        this.password = password;
+        this.role = role;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(role.name()));
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/project/likelion14thbe/global/security/userdetails/CustomUserDetailsService.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/userdetails/CustomUserDetailsService.java
@@ -1,0 +1,28 @@
+package com.project.likelion14thbe.global.security.userdetails;
+
+import com.project.likelion14thbe.domain.member.entity.Member;
+import com.project.likelion14thbe.domain.member.exception.MemberErrorCode;
+import com.project.likelion14thbe.domain.member.exception.MemberException;
+import com.project.likelion14thbe.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        log.info("[ CustomUserDetailsService ] Email 을 이용하여 User 를 검색합니다.");
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+        return new CustomUserDetails(member.getEmail(), member.getPassword(), member.getRole());
+    }
+}

--- a/src/main/java/com/project/likelion14thbe/global/security/utils/HttpResponseUtil.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/utils/HttpResponseUtil.java
@@ -1,0 +1,41 @@
+package com.project.likelion14thbe.global.security.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.likelion14thbe.global.apiPayload.CustomResponse;
+import com.project.likelion14thbe.global.apiPayload.code.BaseErrorCode;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.http.MediaType;
+
+import java.io.IOException;
+
+/**
+ * 필터·시큐리티 핸들러 등 컨트롤러 밖에서 표준 CustomResponse 에러 응답을 직접 내려준다.
+ *
+ * <p>그동안 JwtAuthorizationFilter 는 토큰 에러를 plain text 로 써서 다른 401
+ * (무토큰=AUTH401_4 JSON)과 응답 형식이 달랐다. 이 유틸로 모든 인증/인가 에러를
+ * {isSuccess, code, message, result} envelope 로 통일한다. (팀장 Capstone-BackEnd
+ * global.security.utils.HttpResponseUtil 패턴 참고)
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class HttpResponseUtil {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static void setErrorResponse(
+            HttpServletResponse response,
+            BaseErrorCode errorCode
+    ) throws IOException {
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        CustomResponse<Object> body = CustomResponse.onFailure(
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                null
+        );
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}


### PR DESCRIPTION
# ☝️Issue Number
- #79

## 📌 개요
- 6주차 강의·과제 구현입니다. 시큐리티/JWT 인증 인프라 도입 → 회원가입 BCrypt 암호화 → 5주차 PathVariable 본인 검증을 @AuthenticationPrincipal로 교체 → 로그아웃 핸들러 순으로 진행했습니다.

## 🔁 변경 사항
- Spring Security + JWT 인증 인프라 도입 (CustomLoginFilter / JwtAuthorizationFilter / JwtUtil / CustomUserDetails(Service) / SecurityConfig / CorsConfig / 인증·인가 예외 핸들러)
- 회원가입 비밀번호를 BCrypt로 암호화
- Swagger 진입 URL·/v3/api-docs를 화이트리스트에 추가하고, Swagger 노출용 AuthController로 로그인 명세 작성
- 5주차 PathVariable /{memberId} 본인 검증을 @AuthenticationPrincipal 기반 /members/me로 교체
- 로그아웃 핸들러 추가 — Refresh Token 삭제로 재발급 차단
- JWT 인가 필터의 토큰 에러(위조·만료) 응답을 plain text에서 CustomResponse envelope(AUTH401_2/AUTH401_3)로 통일해 다른 401(무토큰 AUTH401_4)과 형식을 맞췄습니다.

## 🔒 리뷰 반영 — 다른 도메인 시큐리티

팀장 리뷰("다른 도메인들도 시큐리티 적용") 반영.

- Order, Review: 클라이언트가 넘기던 `memberId` 쿼리 파라미터를 제거하고 `@AuthenticationPrincipal`(인증 사용자 email) 기준으로 본인 자원을 식별하도록 교체. 토큰만 있으면 남의 memberId로 주문 취소, 리뷰 수정·삭제, 내역 조회가 되던 IDOR를 제거. 서비스 시그니처를 `String email`로 통일해 Member 도메인과 같은 패턴 적용.
- Product: 등록·수정·삭제를 `ROLE_ADMIN` 전용으로 제한(`@EnableMethodSecurity`와 메서드 `@PreAuthorize`). 목록·상세 조회는 기존 인증 정책 유지.
- ADMIN 멱등 시드 추가(`DataInitializer`, 부팅 시 1회, 이미 있으면 skip). 데모 계정 `admin@likelion.com` / `admin1234!`.

### Breaking
- `/api/v1/orders`, `/api/v1/reviews` 등 요청에서 `memberId` 쿼리 파라미터가 사라짐.

## 📸 스크린샷

