### PR TITLE
🔒 feat: 카카오 네이버 OAuth 와 토큰 무효화를 도입한다 (#91)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
 
+	// WebClient (OAuth 외부 호출)
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 	// Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -62,9 +62,10 @@ dependencies {
 	// Redis (토큰 무효화 컷오프 저장)
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-	// Testcontainers (통합 테스트용 실제 Redis)
+	// Testcontainers (통합 테스트용 실제 Redis/MySQL)
 	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
 	testImplementation 'org.testcontainers:testcontainers'
+	testImplementation 'org.testcontainers:testcontainers-mysql:2.0.3'
 
 	// Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	// Testcontainers (통합 테스트용 실제 Redis)
-	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+	testImplementation 'org.testcontainers:testcontainers'
 
 	// Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,12 @@ dependencies {
 	// WebClient (OAuth 외부 호출)
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+	// Redis (토큰 무효화 컷오프 저장)
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// Testcontainers (통합 테스트용 실제 Redis)
+	testImplementation 'org.testcontainers:junit-jupiter'
+
 	// Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 }

--- a/src/main/java/com/project/likelion14thbe/domain/auth/controller/OAuthController.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/controller/OAuthController.java
@@ -1,0 +1,60 @@
+package com.project.likelion14thbe.domain.auth.controller;
+
+import com.project.likelion14thbe.domain.auth.controller.docs.OAuthDocs;
+import com.project.likelion14thbe.domain.auth.dto.response.JwtDTO;
+import com.project.likelion14thbe.domain.auth.enums.Provider;
+import com.project.likelion14thbe.domain.auth.service.command.OAuthCommandService;
+import com.project.likelion14thbe.global.apiPayload.CustomResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class OAuthController implements OAuthDocs {
+
+    private final OAuthCommandService oAuthCommandService;
+
+    @Override
+    @GetMapping("/auth/kakao")
+    public void kakaoAuthorize(HttpServletResponse response, HttpSession session) throws IOException {
+        oAuthCommandService.redirect(Provider.KAKAO, response, session);
+    }
+
+    @Override
+    @GetMapping("/kakao/callback")
+    public CustomResponse<JwtDTO> kakaoCallback(
+            @RequestParam(value = "code", required = false) String code,
+            @RequestParam(value = "state", required = false) String state,
+            @RequestParam(value = "error", required = false) String error,
+            HttpSession session
+    ) {
+        return CustomResponse.onSuccess(
+                oAuthCommandService.handleCallback(Provider.KAKAO, code, state, error, session));
+    }
+
+    @Override
+    @GetMapping("/auth/naver")
+    public void naverAuthorize(HttpServletResponse response, HttpSession session) throws IOException {
+        oAuthCommandService.redirect(Provider.NAVER, response, session);
+    }
+
+    @Override
+    @GetMapping("/naver/callback")
+    public CustomResponse<JwtDTO> naverCallback(
+            @RequestParam(value = "code", required = false) String code,
+            @RequestParam(value = "state", required = false) String state,
+            @RequestParam(value = "error", required = false) String error,
+            HttpSession session
+    ) {
+        return CustomResponse.onSuccess(
+                oAuthCommandService.handleCallback(Provider.NAVER, code, state, error, session));
+    }
+}

--- a/src/main/java/com/project/likelion14thbe/domain/auth/controller/docs/OAuthDocs.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/controller/docs/OAuthDocs.java
@@ -1,0 +1,34 @@
+package com.project.likelion14thbe.domain.auth.controller.docs;
+
+import com.project.likelion14thbe.domain.auth.dto.response.JwtDTO;
+import com.project.likelion14thbe.global.apiPayload.CustomResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+import java.io.IOException;
+
+@Tag(name = "OAuth", description = "소셜 로그인 API (카카오·네이버). 브라우저로 진입 URL 접속 시 Provider 인가 페이지로 리다이렉트된다.")
+public interface OAuthDocs {
+
+    @Operation(summary = "카카오 로그인 진입", description = "카카오 인가 페이지로 리다이렉트한다.")
+    void kakaoAuthorize(HttpServletResponse response, HttpSession session) throws IOException;
+
+    @Operation(summary = "카카오 콜백", description = "인가 코드로 로그인 또는 회원가입 후 일반 로그인과 동일한 JwtDTO를 반환한다. 인가 거부 시 OAUTH_ACCESS_DENIED(AUTH401_5)를 반환한다.")
+    @ApiResponses(@ApiResponse(responseCode = "200", description = "로그인 성공",
+            content = @Content(schema = @Schema(implementation = JwtDTO.class))))
+    CustomResponse<JwtDTO> kakaoCallback(String code, String state, String error, HttpSession session);
+
+    @Operation(summary = "네이버 로그인 진입", description = "네이버 인가 페이지로 리다이렉트한다.")
+    void naverAuthorize(HttpServletResponse response, HttpSession session) throws IOException;
+
+    @Operation(summary = "네이버 콜백", description = "인가 코드로 로그인 또는 회원가입 후 일반 로그인과 동일한 JwtDTO를 반환한다. 인가 거부 시 OAUTH_ACCESS_DENIED(AUTH401_5)를 반환한다.")
+    @ApiResponses(@ApiResponse(responseCode = "200", description = "로그인 성공",
+            content = @Content(schema = @Schema(implementation = JwtDTO.class))))
+    CustomResponse<JwtDTO> naverCallback(String code, String state, String error, HttpSession session);
+}

--- a/src/main/java/com/project/likelion14thbe/domain/auth/converter/OAuthConverter.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/converter/OAuthConverter.java
@@ -1,0 +1,40 @@
+package com.project.likelion14thbe.domain.auth.converter;
+
+import com.project.likelion14thbe.domain.auth.dto.oauth.OAuthUserInfo;
+import com.project.likelion14thbe.domain.auth.entity.SocialAccount;
+import com.project.likelion14thbe.domain.member.entity.Member;
+import com.project.likelion14thbe.domain.member.enums.Role;
+
+public class OAuthConverter {
+
+    private OAuthConverter() {
+    }
+
+    // encodedPassword: Member.password(nullable=false) 스키마 호환용 BCrypt(UUID) 값.
+    // 사용자가 아는 비밀번호가 아니므로 일반 로그인 자격증명으로 취급하지 않는다.
+    public static Member toMember(OAuthUserInfo info, String encodedPassword) {
+        String name = (info.nickname() != null && !info.nickname().isBlank())
+                ? info.nickname()
+                : localPartOf(info.email());
+        return Member.builder()
+                .name(name)
+                .email(info.email())
+                .password(encodedPassword)
+                .profileImage(info.profileImage())
+                .role(Role.ROLE_USER)
+                .build();
+    }
+
+    public static SocialAccount toSocialAccount(OAuthUserInfo info, Member member) {
+        return SocialAccount.builder()
+                .provider(info.provider())
+                .providerId(info.providerId())
+                .member(member)
+                .build();
+    }
+
+    private static String localPartOf(String email) {
+        int at = email.indexOf('@');
+        return at > 0 ? email.substring(0, at) : email;
+    }
+}

--- a/src/main/java/com/project/likelion14thbe/domain/auth/dto/oauth/KakaoTokenResponse.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/dto/oauth/KakaoTokenResponse.java
@@ -1,0 +1,14 @@
+package com.project.likelion14thbe.domain.auth.dto.oauth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoTokenResponse(
+        @JsonProperty("token_type") String tokenType,
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("refresh_token") String refreshToken,
+        @JsonProperty("expires_in") Integer expiresIn,
+        @JsonProperty("scope") String scope
+) {
+}

--- a/src/main/java/com/project/likelion14thbe/domain/auth/dto/oauth/KakaoUserInfoResponse.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/dto/oauth/KakaoUserInfoResponse.java
@@ -1,0 +1,24 @@
+package com.project.likelion14thbe.domain.auth.dto.oauth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoUserInfoResponse(
+        @JsonProperty("id") Long id,
+        @JsonProperty("kakao_account") KakaoAccount kakaoAccount
+) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record KakaoAccount(
+            @JsonProperty("email") String email,
+            @JsonProperty("profile") Profile profile
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Profile(
+            @JsonProperty("nickname") String nickname,
+            @JsonProperty("profile_image_url") String profileImageUrl
+    ) {
+    }
+}

--- a/src/main/java/com/project/likelion14thbe/domain/auth/dto/oauth/NaverTokenResponse.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/dto/oauth/NaverTokenResponse.java
@@ -1,0 +1,16 @@
+package com.project.likelion14thbe.domain.auth.dto.oauth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record NaverTokenResponse(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("refresh_token") String refreshToken,
+        @JsonProperty("token_type") String tokenType,
+        // 네이버 토큰 응답의 expires_in은 숫자 문자열로 내려오므로 String으로 받는다
+        @JsonProperty("expires_in") String expiresIn,
+        @JsonProperty("error") String error,
+        @JsonProperty("error_description") String errorDescription
+) {
+}

--- a/src/main/java/com/project/likelion14thbe/domain/auth/dto/oauth/NaverUserInfoResponse.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/dto/oauth/NaverUserInfoResponse.java
@@ -1,0 +1,21 @@
+package com.project.likelion14thbe.domain.auth.dto.oauth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record NaverUserInfoResponse(
+        @JsonProperty("resultcode") String resultCode,
+        @JsonProperty("message") String message,
+        @JsonProperty("response") NaverAccount response
+) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record NaverAccount(
+            @JsonProperty("id") String id,
+            @JsonProperty("email") String email,
+            @JsonProperty("nickname") String nickname,
+            @JsonProperty("name") String name,
+            @JsonProperty("profile_image") String profileImage
+    ) {
+    }
+}

--- a/src/main/java/com/project/likelion14thbe/domain/auth/dto/oauth/OAuthUserInfo.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/dto/oauth/OAuthUserInfo.java
@@ -1,0 +1,14 @@
+package com.project.likelion14thbe.domain.auth.dto.oauth;
+
+import com.project.likelion14thbe.domain.auth.enums.Provider;
+import lombok.Builder;
+
+@Builder
+public record OAuthUserInfo(
+        Provider provider,
+        String providerId,
+        String email,
+        String nickname,
+        String profileImage
+) {
+}

--- a/src/main/java/com/project/likelion14thbe/domain/auth/entity/SocialAccount.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/entity/SocialAccount.java
@@ -1,0 +1,52 @@
+package com.project.likelion14thbe.domain.auth.entity;
+
+import com.project.likelion14thbe.domain.auth.enums.Provider;
+import com.project.likelion14thbe.domain.member.entity.Member;
+import com.project.likelion14thbe.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(
+        name = "social_account",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_social_provider_provider_id",
+                columnNames = {"provider", "provider_id"}
+        )
+)
+public class SocialAccount extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider", nullable = false, length = 20)
+    private Provider provider;
+
+    @Column(name = "provider_id", nullable = false, length = 100)
+    private String providerId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+}

--- a/src/main/java/com/project/likelion14thbe/domain/auth/enums/Provider.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/enums/Provider.java
@@ -1,0 +1,6 @@
+package com.project.likelion14thbe.domain.auth.enums;
+
+public enum Provider {
+    KAKAO,
+    NAVER
+}

--- a/src/main/java/com/project/likelion14thbe/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/exception/AuthErrorCode.java
@@ -15,7 +15,24 @@ public enum AuthErrorCode implements BaseErrorCode {
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH401_4", "인증이 필요합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH403_1", "권한이 없습니다."),
     MEMBER_NOT_FOUND_AUTH(HttpStatus.NOT_FOUND, "AUTH404_1", "계정을 찾을 수 없습니다."),
-    BODY_PARSE_ERROR(HttpStatus.BAD_REQUEST, "AUTH400_1", "Request Body 파싱 중 오류가 발생했습니다.");
+    BODY_PARSE_ERROR(HttpStatus.BAD_REQUEST, "AUTH400_1", "Request Body 파싱 중 오류가 발생했습니다."),
+
+    // KAKAO (Provider별 코드)
+    KAKAO_INVALID_STATE(HttpStatus.BAD_REQUEST, "KAKAO_001", "유효하지 않은 요청입니다."),
+    KAKAO_TOKEN_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "KAKAO_002", "카카오 소셜 로그인 토큰 발급에 실패했습니다."),
+    KAKAO_USER_INFO_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "KAKAO_003", "카카오 소셜 로그인 사용자 정보 조회에 실패했습니다."),
+
+    // NAVER (Provider별 코드)
+    NAVER_INVALID_STATE(HttpStatus.BAD_REQUEST, "NAVER_001", "유효하지 않은 요청입니다."),
+    NAVER_TOKEN_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "NAVER_002", "네이버 소셜 로그인 토큰 발급에 실패했습니다."),
+    NAVER_USER_INFO_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "NAVER_003", "네이버 소셜 로그인 사용자 정보 조회에 실패했습니다."),
+
+    // 공통 OAuth (이 레포 정본: 도메인PREFIX + HTTP + SEQ)
+    INVALID_OAUTH_REQUEST(HttpStatus.BAD_REQUEST, "AUTH400_2", "잘못된 OAuth 요청입니다."),
+    UNSUPPORTED_OAUTH_PROVIDER(HttpStatus.BAD_REQUEST, "AUTH400_3", "지원하지 않는 소셜 로그인 제공자입니다."),
+    OAUTH_EMAIL_NOT_PROVIDED(HttpStatus.BAD_REQUEST, "AUTH400_4", "소셜 계정에서 이메일을 제공받지 못했습니다."),
+    OAUTH_EMAIL_CONFLICT(HttpStatus.CONFLICT, "AUTH409_1", "이미 동일 이메일로 가입된 계정이 있습니다."),
+    OAUTH_ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "AUTH401_5", "소셜 로그인 동의가 거부되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/project/likelion14thbe/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/exception/AuthErrorCode.java
@@ -32,7 +32,8 @@ public enum AuthErrorCode implements BaseErrorCode {
     UNSUPPORTED_OAUTH_PROVIDER(HttpStatus.BAD_REQUEST, "AUTH400_3", "지원하지 않는 소셜 로그인 제공자입니다."),
     OAUTH_EMAIL_NOT_PROVIDED(HttpStatus.BAD_REQUEST, "AUTH400_4", "소셜 계정에서 이메일을 제공받지 못했습니다."),
     OAUTH_EMAIL_CONFLICT(HttpStatus.CONFLICT, "AUTH409_1", "이미 동일 이메일로 가입된 계정이 있습니다."),
-    OAUTH_ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "AUTH401_5", "소셜 로그인 동의가 거부되었습니다.");
+    OAUTH_ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "AUTH401_5", "소셜 로그인 동의가 거부되었습니다."),
+    INVALIDATED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_6", "로그아웃되었거나 무효화된 토큰입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/project/likelion14thbe/domain/auth/repository/SocialAccountRepository.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/repository/SocialAccountRepository.java
@@ -1,0 +1,11 @@
+package com.project.likelion14thbe.domain.auth.repository;
+
+import com.project.likelion14thbe.domain.auth.entity.SocialAccount;
+import com.project.likelion14thbe.domain.auth.enums.Provider;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SocialAccountRepository extends JpaRepository<SocialAccount, Long> {
+    Optional<SocialAccount> findByProviderAndProviderId(Provider provider, String providerId);
+}

--- a/src/main/java/com/project/likelion14thbe/domain/auth/service/command/OAuthCommandService.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/service/command/OAuthCommandService.java
@@ -1,0 +1,17 @@
+package com.project.likelion14thbe.domain.auth.service.command;
+
+import com.project.likelion14thbe.domain.auth.dto.response.JwtDTO;
+import com.project.likelion14thbe.domain.auth.enums.Provider;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+import java.io.IOException;
+
+public interface OAuthCommandService {
+
+    // 인가 페이지로 리다이렉트. state를 세션에 저장
+    void redirect(Provider provider, HttpServletResponse response, HttpSession session) throws IOException;
+
+    // 콜백 처리: error(거부/실패) 처리, state 검증, 토큰·사용자정보 조회, 로그인 또는 회원가입 후 JwtDTO 반환
+    JwtDTO handleCallback(Provider provider, String code, String state, String error, HttpSession session);
+}

--- a/src/main/java/com/project/likelion14thbe/domain/auth/service/command/OAuthCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/service/command/OAuthCommandServiceImpl.java
@@ -1,0 +1,152 @@
+package com.project.likelion14thbe.domain.auth.service.command;
+
+import com.project.likelion14thbe.domain.auth.converter.OAuthConverter;
+import com.project.likelion14thbe.domain.auth.dto.oauth.OAuthUserInfo;
+import com.project.likelion14thbe.domain.auth.dto.response.JwtDTO;
+import com.project.likelion14thbe.domain.auth.entity.SocialAccount;
+import com.project.likelion14thbe.domain.auth.enums.Provider;
+import com.project.likelion14thbe.domain.auth.exception.AuthErrorCode;
+import com.project.likelion14thbe.domain.auth.exception.AuthException;
+import com.project.likelion14thbe.domain.auth.repository.SocialAccountRepository;
+import com.project.likelion14thbe.domain.auth.strategy.OAuthStrategy;
+import com.project.likelion14thbe.domain.member.entity.Member;
+import com.project.likelion14thbe.domain.member.repository.MemberRepository;
+import com.project.likelion14thbe.global.security.jwt.JwtUtil;
+import com.project.likelion14thbe.global.security.userdetails.CustomUserDetails;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.SecureRandom;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+@Slf4j
+@Service
+public class OAuthCommandServiceImpl implements OAuthCommandService {
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private final Map<Provider, OAuthStrategy> strategyMap = new EnumMap<>(Provider.class);
+    private final SocialAccountRepository socialAccountRepository;
+    private final MemberRepository memberRepository;
+    private final JwtUtil jwtUtil;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    public OAuthCommandServiceImpl(
+            List<OAuthStrategy> strategies,
+            SocialAccountRepository socialAccountRepository,
+            MemberRepository memberRepository,
+            JwtUtil jwtUtil,
+            BCryptPasswordEncoder passwordEncoder
+    ) {
+        for (OAuthStrategy s : strategies) {
+            strategyMap.put(s.getProvider(), s);
+        }
+        this.socialAccountRepository = socialAccountRepository;
+        this.memberRepository = memberRepository;
+        this.jwtUtil = jwtUtil;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    public void redirect(Provider provider, HttpServletResponse response, HttpSession session)
+            throws IOException {
+        OAuthStrategy strategy = getStrategy(provider);
+        String state = new BigInteger(130, SECURE_RANDOM).toString(32);
+        // CSRF 방지용 state를 HttpSession에 저장한다.
+        // SecurityConfig는 SessionCreationPolicy.STATELESS이지만 충돌하지 않는다.
+        // STATELESS는 스프링 시큐리티가 SecurityContext를 세션에 보존하지 않는다는 의미일 뿐,
+        // 서블릿 컨테이너의 세션 메커니즘 자체를 끄지 않는다. 여기서 HttpSession에 직접
+        // setAttribute하면 컨테이너가 실제 세션과 JSESSIONID 쿠키를 생성하고, 브라우저는
+        // OAuth 왕복 동안 이를 보관하므로(콜백은 top-level GET, 쿠키 기본 SameSite=Lax는 전송)
+        // 콜백에서 세션이 복원된다. 팀장 운영 레포 capstone-BackEnd가 동일 패턴으로 실서비스 동작.
+        session.setAttribute(stateKey(provider), state);
+        response.sendRedirect(strategy.buildAuthorizationUrl(state));
+    }
+
+    @Override
+    public JwtDTO handleCallback(Provider provider, String code, String state, String error, HttpSession session) {
+        // 인가 거부 또는 Provider 오류 처리 (state 검증 전)
+        if (error != null && !error.isBlank()) {
+            log.warn("[OAuth] provider={} 인가 거부/에러: {}", provider, error);
+            throw new AuthException(AuthErrorCode.OAUTH_ACCESS_DENIED);
+        }
+        // state 검증 (외부 호출 전, 트랜잭션 밖)
+        Object stored = session.getAttribute(stateKey(provider));
+        if (stored == null || !Objects.equals(stored.toString(), state)) {
+            throw new AuthException(invalidStateCode(provider));
+        }
+        session.removeAttribute(stateKey(provider));
+        log.debug("[OAuth] handleCallback provider={}", provider);
+
+        OAuthStrategy strategy = getStrategy(provider);
+
+        // code 누락 방어
+        if (code == null || code.isBlank()) {
+            throw new AuthException(AuthErrorCode.INVALID_OAUTH_REQUEST);
+        }
+
+        // 외부 Provider 호출은 트랜잭션 밖
+        String accessToken = strategy.exchangeCodeForToken(code, state);
+        OAuthUserInfo userInfo = strategy.fetchUserInfo(accessToken);
+        if (userInfo.email() == null || userInfo.email().isBlank()) {
+            throw new AuthException(AuthErrorCode.OAUTH_EMAIL_NOT_PROVIDED);
+        }
+
+        // DB 변경만 트랜잭션 안
+        Member member = loginOrSignup(userInfo);
+
+        CustomUserDetails userDetails =
+                new CustomUserDetails(member.getEmail(), member.getPassword(), member.getRole());
+        String access = jwtUtil.createJwtAccessToken(userDetails);
+        String refresh = jwtUtil.createJwtRefreshToken(userDetails);
+        return JwtDTO.builder().accessToken(access).refreshToken(refresh).build();
+    }
+
+    @Transactional
+    protected Member loginOrSignup(OAuthUserInfo userInfo) {
+        return socialAccountRepository
+                .findByProviderAndProviderId(userInfo.provider(), userInfo.providerId())
+                .map(SocialAccount::getMember)
+                .orElseGet(() -> signup(userInfo));
+    }
+
+    private Member signup(OAuthUserInfo userInfo) {
+        memberRepository.findByEmailAndNotDeleted(userInfo.email()).ifPresent(m -> {
+            throw new AuthException(AuthErrorCode.OAUTH_EMAIL_CONFLICT);
+        });
+        // 스키마 호환용 비밀번호. 사용자가 아는 값이 아니며 일반 로그인 불가.
+        String schemaCompatPassword = passwordEncoder.encode(UUID.randomUUID().toString());
+        Member member = memberRepository.save(OAuthConverter.toMember(userInfo, schemaCompatPassword));
+        socialAccountRepository.save(OAuthConverter.toSocialAccount(userInfo, member));
+        log.info("[OAuth] 신규 소셜 회원 가입 provider={} email={}", userInfo.provider(), userInfo.email());
+        return member;
+    }
+
+    private OAuthStrategy getStrategy(Provider provider) {
+        OAuthStrategy strategy = strategyMap.get(provider);
+        if (strategy == null) {
+            throw new AuthException(AuthErrorCode.UNSUPPORTED_OAUTH_PROVIDER);
+        }
+        return strategy;
+    }
+
+    private AuthErrorCode invalidStateCode(Provider provider) {
+        return provider == Provider.KAKAO
+                ? AuthErrorCode.KAKAO_INVALID_STATE
+                : AuthErrorCode.NAVER_INVALID_STATE;
+    }
+
+    private String stateKey(Provider provider) {
+        return "OAUTH_STATE_" + provider.name();
+    }
+}

--- a/src/main/java/com/project/likelion14thbe/domain/auth/service/command/OAuthCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/service/command/OAuthCommandServiceImpl.java
@@ -18,7 +18,8 @@ import jakarta.servlet.http.HttpSession;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -40,13 +41,15 @@ public class OAuthCommandServiceImpl implements OAuthCommandService {
     private final MemberRepository memberRepository;
     private final JwtUtil jwtUtil;
     private final BCryptPasswordEncoder passwordEncoder;
+    private final TransactionTemplate transactionTemplate;
 
     public OAuthCommandServiceImpl(
             List<OAuthStrategy> strategies,
             SocialAccountRepository socialAccountRepository,
             MemberRepository memberRepository,
             JwtUtil jwtUtil,
-            BCryptPasswordEncoder passwordEncoder
+            BCryptPasswordEncoder passwordEncoder,
+            PlatformTransactionManager transactionManager
     ) {
         for (OAuthStrategy s : strategies) {
             strategyMap.put(s.getProvider(), s);
@@ -55,6 +58,8 @@ public class OAuthCommandServiceImpl implements OAuthCommandService {
         this.memberRepository = memberRepository;
         this.jwtUtil = jwtUtil;
         this.passwordEncoder = passwordEncoder;
+        // 자기호출 한계를 피하기 위해 프록시 어드바이스 대신 TransactionTemplate 으로 명시 트랜잭션을 연다
+        this.transactionTemplate = new TransactionTemplate(transactionManager);
     }
 
     @Override
@@ -112,18 +117,20 @@ public class OAuthCommandServiceImpl implements OAuthCommandService {
         return JwtDTO.builder().accessToken(access).refreshToken(refresh).build();
     }
 
-    @Transactional
-    protected Member loginOrSignup(OAuthUserInfo userInfo) {
-        return socialAccountRepository
-                .findByProviderAndProviderId(userInfo.provider(), userInfo.providerId())
-                .map(SocialAccount::getMember)
-                .orElseGet(() -> signup(userInfo));
+    private Member loginOrSignup(OAuthUserInfo userInfo) {
+        return transactionTemplate.execute(status ->
+                socialAccountRepository
+                        .findByProviderAndProviderId(userInfo.provider(), userInfo.providerId())
+                        .map(SocialAccount::getMember)
+                        .orElseGet(() -> signup(userInfo))
+        );
     }
 
     private Member signup(OAuthUserInfo userInfo) {
-        memberRepository.findByEmailAndNotDeleted(userInfo.email()).ifPresent(m -> {
+        // Member.email 은 전역 unique 라 soft-delete 회원도 충돌 대상이다(일반 가입과 통일)
+        if (memberRepository.existsByEmail(userInfo.email())) {
             throw new AuthException(AuthErrorCode.OAUTH_EMAIL_CONFLICT);
-        });
+        }
         // 스키마 호환용 비밀번호. 사용자가 아는 값이 아니며 일반 로그인 불가.
         String schemaCompatPassword = passwordEncoder.encode(UUID.randomUUID().toString());
         Member member = memberRepository.save(OAuthConverter.toMember(userInfo, schemaCompatPassword));

--- a/src/main/java/com/project/likelion14thbe/domain/auth/strategy/KakaoOAuthStrategy.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/strategy/KakaoOAuthStrategy.java
@@ -1,0 +1,119 @@
+package com.project.likelion14thbe.domain.auth.strategy;
+
+import com.project.likelion14thbe.domain.auth.dto.oauth.KakaoTokenResponse;
+import com.project.likelion14thbe.domain.auth.dto.oauth.KakaoUserInfoResponse;
+import com.project.likelion14thbe.domain.auth.dto.oauth.OAuthUserInfo;
+import com.project.likelion14thbe.domain.auth.enums.Provider;
+import com.project.likelion14thbe.domain.auth.exception.AuthErrorCode;
+import com.project.likelion14thbe.domain.auth.exception.AuthException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Component
+public class KakaoOAuthStrategy implements OAuthStrategy {
+
+    private static final String AUTHORIZATION_URI = "https://kauth.kakao.com/oauth/authorize";
+    private static final String TOKEN_URI = "https://kauth.kakao.com/oauth/token";
+    private static final String USER_INFO_URI = "https://kapi.kakao.com/v2/user/me";
+
+    private final WebClient webClient;
+    private final String clientId;
+    private final String clientSecret;
+    private final String redirectUri;
+
+    public KakaoOAuthStrategy(
+            WebClient oauthWebClient,
+            @Value("${kakao.client.id}") String clientId,
+            @Value("${kakao.client.secret}") String clientSecret,
+            @Value("${kakao.redirect-uri}") String redirectUri
+    ) {
+        this.webClient = oauthWebClient;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.redirectUri = redirectUri;
+    }
+
+    @Override
+    public Provider getProvider() {
+        return Provider.KAKAO;
+    }
+
+    @Override
+    public String buildAuthorizationUrl(String state) {
+        return UriComponentsBuilder
+                .fromUriString(AUTHORIZATION_URI)
+                .queryParam("response_type", "code")
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", redirectUri)
+                .queryParam("state", state)
+                .build()
+                .toUriString();
+    }
+
+    @Override
+    public String exchangeCodeForToken(String code, String state) {
+        // Kakao 토큰 요청 사양상 state 불필요 — OAuthStrategy 인터페이스 일관성을 위해 파라미터만 유지
+        KakaoTokenResponse token;
+        try {
+            token = webClient.post()
+                    .uri(TOKEN_URI)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(BodyInserters.fromFormData("grant_type", "authorization_code")
+                            .with("client_id", clientId)
+                            .with("client_secret", clientSecret)
+                            .with("redirect_uri", redirectUri)
+                            .with("code", code))
+                    .retrieve()
+                    .bodyToMono(KakaoTokenResponse.class)
+                    .block();
+        } catch (WebClientRequestException | WebClientResponseException e) {
+            throw new AuthException(AuthErrorCode.KAKAO_TOKEN_REQUEST_FAILED);
+        } catch (Exception e) {
+            throw new AuthException(AuthErrorCode.INVALID_OAUTH_REQUEST);
+        }
+        if (token == null || token.accessToken() == null) {
+            throw new AuthException(AuthErrorCode.KAKAO_TOKEN_REQUEST_FAILED);
+        }
+        return token.accessToken();
+    }
+
+    @Override
+    public OAuthUserInfo fetchUserInfo(String accessToken) {
+        KakaoUserInfoResponse info;
+        try {
+            info = webClient.get()
+                    .uri(USER_INFO_URI)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .retrieve()
+                    .bodyToMono(KakaoUserInfoResponse.class)
+                    .block();
+        } catch (WebClientRequestException | WebClientResponseException e) {
+            throw new AuthException(AuthErrorCode.KAKAO_USER_INFO_REQUEST_FAILED);
+        } catch (Exception e) {
+            throw new AuthException(AuthErrorCode.INVALID_OAUTH_REQUEST);
+        }
+        if (info == null || info.id() == null || info.kakaoAccount() == null) {
+            throw new AuthException(AuthErrorCode.KAKAO_USER_INFO_REQUEST_FAILED);
+        }
+
+        KakaoUserInfoResponse.KakaoAccount account = info.kakaoAccount();
+        String nickname = account.profile() != null ? account.profile().nickname() : null;
+        String profileImage = account.profile() != null ? account.profile().profileImageUrl() : null;
+
+        return OAuthUserInfo.builder()
+                .provider(Provider.KAKAO)
+                .providerId(String.valueOf(info.id()))
+                .email(account.email())
+                .nickname(nickname)
+                .profileImage(profileImage)
+                .build();
+    }
+}

--- a/src/main/java/com/project/likelion14thbe/domain/auth/strategy/NaverOAuthStrategy.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/strategy/NaverOAuthStrategy.java
@@ -1,0 +1,115 @@
+package com.project.likelion14thbe.domain.auth.strategy;
+
+import com.project.likelion14thbe.domain.auth.dto.oauth.NaverTokenResponse;
+import com.project.likelion14thbe.domain.auth.dto.oauth.NaverUserInfoResponse;
+import com.project.likelion14thbe.domain.auth.dto.oauth.OAuthUserInfo;
+import com.project.likelion14thbe.domain.auth.enums.Provider;
+import com.project.likelion14thbe.domain.auth.exception.AuthErrorCode;
+import com.project.likelion14thbe.domain.auth.exception.AuthException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Component
+public class NaverOAuthStrategy implements OAuthStrategy {
+
+    private static final String AUTHORIZATION_URI = "https://nid.naver.com/oauth2.0/authorize";
+    private static final String TOKEN_URI = "https://nid.naver.com/oauth2.0/token";
+    private static final String USER_INFO_URI = "https://openapi.naver.com/v1/nid/me";
+
+    private final WebClient webClient;
+    private final String clientId;
+    private final String clientSecret;
+    private final String redirectUri;
+
+    public NaverOAuthStrategy(
+            WebClient oauthWebClient,
+            @Value("${naver.client.id}") String clientId,
+            @Value("${naver.client.secret}") String clientSecret,
+            @Value("${naver.redirect-uri}") String redirectUri
+    ) {
+        this.webClient = oauthWebClient;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.redirectUri = redirectUri;
+    }
+
+    @Override
+    public Provider getProvider() {
+        return Provider.NAVER;
+    }
+
+    @Override
+    public String buildAuthorizationUrl(String state) {
+        return UriComponentsBuilder
+                .fromUriString(AUTHORIZATION_URI)
+                .queryParam("response_type", "code")
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", redirectUri)
+                .queryParam("state", state)
+                .build()
+                .toUriString();
+    }
+
+    @Override
+    public String exchangeCodeForToken(String code, String state) {
+        NaverTokenResponse token;
+        try {
+            token = webClient.post()
+                    .uri(TOKEN_URI)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(BodyInserters.fromFormData("grant_type", "authorization_code")
+                            .with("client_id", clientId)
+                            .with("client_secret", clientSecret)
+                            .with("code", code)
+                            .with("state", state))
+                    .retrieve()
+                    .bodyToMono(NaverTokenResponse.class)
+                    .block();
+        } catch (WebClientRequestException | WebClientResponseException e) {
+            throw new AuthException(AuthErrorCode.NAVER_TOKEN_REQUEST_FAILED);
+        } catch (Exception e) {
+            throw new AuthException(AuthErrorCode.INVALID_OAUTH_REQUEST);
+        }
+        if (token == null || token.accessToken() == null) {
+            throw new AuthException(AuthErrorCode.NAVER_TOKEN_REQUEST_FAILED);
+        }
+        return token.accessToken();
+    }
+
+    @Override
+    public OAuthUserInfo fetchUserInfo(String accessToken) {
+        NaverUserInfoResponse info;
+        try {
+            info = webClient.get()
+                    .uri(USER_INFO_URI)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .retrieve()
+                    .bodyToMono(NaverUserInfoResponse.class)
+                    .block();
+        } catch (WebClientRequestException | WebClientResponseException e) {
+            throw new AuthException(AuthErrorCode.NAVER_USER_INFO_REQUEST_FAILED);
+        } catch (Exception e) {
+            throw new AuthException(AuthErrorCode.INVALID_OAUTH_REQUEST);
+        }
+        if (info == null || info.response() == null || info.response().id() == null) {
+            throw new AuthException(AuthErrorCode.NAVER_USER_INFO_REQUEST_FAILED);
+        }
+
+        NaverUserInfoResponse.NaverAccount account = info.response();
+        return OAuthUserInfo.builder()
+                .provider(Provider.NAVER)
+                .providerId(account.id())
+                .email(account.email())
+                .nickname(account.nickname())
+                .profileImage(account.profileImage())
+                .build();
+    }
+}

--- a/src/main/java/com/project/likelion14thbe/domain/auth/strategy/OAuthStrategy.java
+++ b/src/main/java/com/project/likelion14thbe/domain/auth/strategy/OAuthStrategy.java
@@ -1,0 +1,19 @@
+package com.project.likelion14thbe.domain.auth.strategy;
+
+import com.project.likelion14thbe.domain.auth.dto.oauth.OAuthUserInfo;
+import com.project.likelion14thbe.domain.auth.enums.Provider;
+
+public interface OAuthStrategy {
+
+    // 이 전략이 처리하는 Provider
+    Provider getProvider();
+
+    // 인가 코드 요청 URL 생성 (state는 CSRF 방지용)
+    String buildAuthorizationUrl(String state);
+
+    // 인가 코드로 액세스 토큰 교환. 네이버는 state를 토큰 요청에 동봉, 카카오는 무시
+    String exchangeCodeForToken(String code, String state);
+
+    // 액세스 토큰으로 사용자 정보 조회 후 중립 모델로 변환
+    OAuthUserInfo fetchUserInfo(String accessToken);
+}

--- a/src/main/java/com/project/likelion14thbe/domain/member/service/command/MemberCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion14thbe/domain/member/service/command/MemberCommandServiceImpl.java
@@ -7,6 +7,7 @@ import com.project.likelion14thbe.domain.member.entity.Member;
 import com.project.likelion14thbe.domain.member.exception.MemberErrorCode;
 import com.project.likelion14thbe.domain.member.exception.MemberException;
 import com.project.likelion14thbe.domain.member.repository.MemberRepository;
+import com.project.likelion14thbe.global.security.token.TokenInvalidationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -19,6 +20,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
     private final MemberRepository memberRepository;
     private final BCryptPasswordEncoder passwordEncoder;
+    private final TokenInvalidationService tokenInvalidationService;
 
     @Override
     public MemberResDTO.SignUpResDTO signUp(MemberReqDTO.SignUpReqDTO request) {
@@ -37,6 +39,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         member.updatePassword(passwordEncoder.encode(dto.password()));
+        tokenInvalidationService.invalidateUser(email);
     }
 
     @Override
@@ -45,5 +48,6 @@ public class MemberCommandServiceImpl implements MemberCommandService {
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         member.softDelete();
+        tokenInvalidationService.invalidateUser(email);
     }
 }

--- a/src/main/java/com/project/likelion14thbe/global/config/OAuthWebClientConfig.java
+++ b/src/main/java/com/project/likelion14thbe/global/config/OAuthWebClientConfig.java
@@ -1,0 +1,29 @@
+package com.project.likelion14thbe.global.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class OAuthWebClientConfig {
+
+    // OAuth Provider 호출 전용 WebClient. Provider 장애가 로그인 스레드를 오래 점유하지 않도록 타임아웃을 둔다.
+    @Bean
+    public WebClient oauthWebClient() {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
+                .responseTimeout(Duration.ofSeconds(5))
+                .doOnConnected(conn -> conn.addHandlerLast(new ReadTimeoutHandler(5, TimeUnit.SECONDS)));
+
+        return WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+}

--- a/src/main/java/com/project/likelion14thbe/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final CustomLogoutHandler customLogoutHandler;
+    private final com.project.likelion14thbe.global.security.token.TokenInvalidationService tokenInvalidationService;
 
     // 인증 없이 접근 허용할 URL
     private final String[] allowUrl = {
@@ -68,7 +69,7 @@ public class SecurityConfig {
                         // 그 외는 인증 필수
                         .anyRequest().authenticated())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .addFilterBefore(new JwtAuthorizationFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthorizationFilter(jwtUtil, tokenInvalidationService), UsernamePasswordAuthenticationFilter.class)
                 .addFilterAt(loginFilter, UsernamePasswordAuthenticationFilter.class)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(HttpBasicConfigurer::disable)

--- a/src/main/java/com/project/likelion14thbe/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/config/SecurityConfig.java
@@ -41,6 +41,10 @@ public class SecurityConfig {
     // 인증 없이 접근 허용할 URL
     private final String[] allowUrl = {
             "/api/v1/login",                 // CustomLoginFilter 처리
+            "/api/v1/auth/kakao",            // 카카오 인가 진입
+            "/api/v1/kakao/callback",        // 카카오 콜백
+            "/api/v1/auth/naver",            // 네이버 인가 진입
+            "/api/v1/naver/callback",        // 네이버 콜백
             "/swagger-ui.html",
             "/swagger-ui/**",
             "/v3/api-docs",

--- a/src/main/java/com/project/likelion14thbe/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import com.project.likelion14thbe.global.security.handler.CustomLogoutHandler;
 import com.project.likelion14thbe.global.security.handler.JwtAccessDeniedHandler;
 import com.project.likelion14thbe.global.security.handler.JwtAuthenticationEntryPoint;
 import com.project.likelion14thbe.global.security.jwt.JwtUtil;
+import com.project.likelion14thbe.global.security.token.TokenInvalidationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -37,7 +38,7 @@ public class SecurityConfig {
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final CustomLogoutHandler customLogoutHandler;
-    private final com.project.likelion14thbe.global.security.token.TokenInvalidationService tokenInvalidationService;
+    private final TokenInvalidationService tokenInvalidationService;
 
     // 인증 없이 접근 허용할 URL
     private final String[] allowUrl = {

--- a/src/main/java/com/project/likelion14thbe/global/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/filter/JwtAuthorizationFilter.java
@@ -3,6 +3,8 @@ package com.project.likelion14thbe.global.security.filter;
 import com.project.likelion14thbe.domain.auth.exception.AuthErrorCode;
 import com.project.likelion14thbe.domain.member.enums.Role;
 import com.project.likelion14thbe.global.security.jwt.JwtUtil;
+import com.project.likelion14thbe.global.security.token.InvalidatedTokenException;
+import com.project.likelion14thbe.global.security.token.TokenInvalidationService;
 import com.project.likelion14thbe.global.security.userdetails.CustomUserDetails;
 import com.project.likelion14thbe.global.security.utils.HttpResponseUtil;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -25,6 +27,7 @@ import java.io.IOException;
 public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
+    private final TokenInvalidationService tokenInvalidationService;
 
     @Override
     protected void doFilterInternal(
@@ -50,6 +53,9 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         } catch (ExpiredJwtException e) {
             logger.warn("[ JwtAuthorizationFilter ] accessToken 이 만료되었습니다.");
             HttpResponseUtil.setErrorResponse(response, AuthErrorCode.EXPIRED_TOKEN);
+        } catch (InvalidatedTokenException e) {
+            logger.warn("[ JwtAuthorizationFilter ] 무효화된 토큰입니다.");
+            HttpResponseUtil.setErrorResponse(response, AuthErrorCode.INVALIDATED_TOKEN);
         } catch (SecurityException e) {
             logger.warn("[ JwtAuthorizationFilter ] 잘못된 토큰입니다.");
             HttpResponseUtil.setErrorResponse(response, AuthErrorCode.INVALID_TOKEN);
@@ -63,6 +69,13 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         log.info("[ JwtAuthorizationFilter ] Access Token 유효성 검증 성공.");
 
         String email = jwtUtil.getEmail(accessToken);
+
+        long issuedAt = jwtUtil.getIssuedAt(accessToken);
+        if (tokenInvalidationService.isInvalidated(email, issuedAt)) {
+            log.info("[ JwtAuthorizationFilter ] 무효화된 토큰 거부 : {}", email);
+            throw new InvalidatedTokenException();
+        }
+
         Role role = jwtUtil.getRoles(accessToken);
 
         CustomUserDetails customUserDetails = new CustomUserDetails(email, null, role);

--- a/src/main/java/com/project/likelion14thbe/global/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/filter/JwtAuthorizationFilter.java
@@ -51,13 +51,13 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
 
         } catch (ExpiredJwtException e) {
-            logger.warn("[ JwtAuthorizationFilter ] accessToken 이 만료되었습니다.");
+            log.warn("[ JwtAuthorizationFilter ] accessToken 이 만료되었습니다.");
             HttpResponseUtil.setErrorResponse(response, AuthErrorCode.EXPIRED_TOKEN);
         } catch (InvalidatedTokenException e) {
-            logger.warn("[ JwtAuthorizationFilter ] 무효화된 토큰입니다.");
+            log.warn("[ JwtAuthorizationFilter ] 무효화된 토큰입니다.");
             HttpResponseUtil.setErrorResponse(response, AuthErrorCode.INVALIDATED_TOKEN);
         } catch (SecurityException e) {
-            logger.warn("[ JwtAuthorizationFilter ] 잘못된 토큰입니다.");
+            log.warn("[ JwtAuthorizationFilter ] 잘못된 토큰입니다.");
             HttpResponseUtil.setErrorResponse(response, AuthErrorCode.INVALID_TOKEN);
         }
     }

--- a/src/main/java/com/project/likelion14thbe/global/security/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/handler/CustomLogoutHandler.java
@@ -2,6 +2,7 @@ package com.project.likelion14thbe.global.security.handler;
 
 import com.project.likelion14thbe.domain.auth.repository.TokenRepository;
 import com.project.likelion14thbe.global.security.jwt.JwtUtil;
+import com.project.likelion14thbe.global.security.token.TokenInvalidationService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +18,7 @@ public class CustomLogoutHandler implements LogoutHandler {
 
     private final JwtUtil jwtUtil;
     private final TokenRepository tokenRepository;
-    private final com.project.likelion14thbe.global.security.token.TokenInvalidationService tokenInvalidationService;
+    private final TokenInvalidationService tokenInvalidationService;
 
     @Override
     public void logout(

--- a/src/main/java/com/project/likelion14thbe/global/security/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/handler/CustomLogoutHandler.java
@@ -17,6 +17,7 @@ public class CustomLogoutHandler implements LogoutHandler {
 
     private final JwtUtil jwtUtil;
     private final TokenRepository tokenRepository;
+    private final com.project.likelion14thbe.global.security.token.TokenInvalidationService tokenInvalidationService;
 
     @Override
     public void logout(
@@ -35,7 +36,8 @@ public class CustomLogoutHandler implements LogoutHandler {
         try {
             String email = jwtUtil.getEmail(accessToken);
             tokenRepository.deleteById(email);
-            log.info("[ Logout Handler ] Refresh Token 삭제 완료 : {}", email);
+            tokenInvalidationService.invalidateUser(email);
+            log.info("[ Logout Handler ] Refresh Token 삭제 및 무효화 컷오프 기록 완료 : {}", email);
         } catch (Exception e) {
             log.warn("[ Logout Handler ] Refresh Token 삭제 실패 : {}", e.getMessage());
         }

--- a/src/main/java/com/project/likelion14thbe/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/jwt/JwtUtil.java
@@ -32,11 +32,15 @@ public class JwtUtil {
     private final TokenRepository tokenRepository;
 
     public JwtUtil(
-            @Value("${spring.jwt.secret:dGhpc2lzYWxvbmdlbm91Z2hzZWNyZXRrZXlmb3JqdzI1NmFsZ29yaXRobTEyMzQ1Njc4OTA=}") String secret,
+            @Value("${spring.jwt.secret}") String secret,
             @Value("${spring.jwt.token.access-expiration-time:1800000}") Long access,
             @Value("${spring.jwt.token.refresh-expiration-time:1209600000}") Long refresh,
             TokenRepository tokenRepository
     ) {
+        // HS256 권장 키 길이(>= 32바이트) 미만이면 위조 위험이라 기동을 차단한다
+        if (secret == null || secret.isBlank() || secret.getBytes(StandardCharsets.UTF_8).length < 32) {
+            throw new IllegalStateException("spring.jwt.secret 미설정 또는 너무 짧음(>= 32바이트 필요)");
+        }
         this.secretKey = new SecretKeySpec(
                 secret.getBytes(StandardCharsets.UTF_8),
                 Jwts.SIG.HS256.key().build().getAlgorithm()
@@ -147,25 +151,31 @@ public class JwtUtil {
             log.warn("[ JwtUtil ] Request Header 에 토큰이 존재하지 않습니다.");
             return null;
         }
-        return tokenFromHeader.split(" ")[1];
+        // "Bearer " 뒤가 비어 있으면 토큰 없음과 동등하게 처리한다
+        String token = tokenFromHeader.substring("Bearer ".length()).trim();
+        if (token.isEmpty()) {
+            log.warn("[ JwtUtil ] Bearer 다음 토큰이 비어 있습니다.");
+            return null;
+        }
+        return token;
     }
 
     // 토큰 유효성 검증 (서명 + 만료)
     public void validateToken(String token) {
         log.info("[ JwtUtil ] 토큰의 유효성을 검증합니다.");
         try {
-            // 시스템 시계 오차 3분 허용
-            long seconds = 3 * 60;
-            boolean isExpired = Jwts.parser()
-                    .clockSkewSeconds(seconds)
+            // 시스템 시계 오차만 허용한다(NTP 권장 수준)
+            long clockSkewSeconds = 5;
+            Date expiration = Jwts.parser()
+                    .clockSkewSeconds(clockSkewSeconds)
                     .verifyWith(secretKey)
                     .build()
                     .parseSignedClaims(token)
                     .getPayload()
-                    .getExpiration()
-                    .before(new Date());
-            if (isExpired) {
-                log.info("만료된 JWT 토큰입니다.");
+                    .getExpiration();
+            // clockSkew 안의 만료 토큰은 JJWT 가 통과시키므로 여기서 직접 거부한다
+            if (expiration.before(new Date())) {
+                throw new ExpiredJwtException(null, null, "만료된 JWT 토큰입니다.");
             }
         } catch (SecurityException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
             throw new SecurityException("잘못된 토큰입니다.");

--- a/src/main/java/com/project/likelion14thbe/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/jwt/JwtUtil.java
@@ -61,6 +61,22 @@ public class JwtUtil {
         }
     }
 
+    // JWT 토큰의 발급 시각(iat)을 epoch millis로 추출
+    public long getIssuedAt(String token) {
+        log.info("[ JwtUtil ] 토큰에서 발급 시각을 추출합니다.");
+        try {
+            return Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .getIssuedAt()
+                    .getTime();
+        } catch (Exception e) {
+            throw new SecurityException("잘못된 토큰입니다.");
+        }
+    }
+
     // JWT 토큰에서 사용자 권한(role) 추출
     public Role getRoles(String token) {
         log.info("[ JwtUtil ] 토큰에서 권한을 추출합니다.");

--- a/src/main/java/com/project/likelion14thbe/global/security/token/InvalidatedTokenException.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/token/InvalidatedTokenException.java
@@ -1,0 +1,12 @@
+package com.project.likelion14thbe.global.security.token;
+
+/**
+ * 사용자별 컷오프에 의해 무효화된 토큰으로 접근 시 던진다.
+ * JwtAuthorizationFilter가 잡아 AUTH401_6으로 응답한다.
+ */
+public class InvalidatedTokenException extends RuntimeException {
+
+    public InvalidatedTokenException() {
+        super("무효화된 토큰입니다.");
+    }
+}

--- a/src/main/java/com/project/likelion14thbe/global/security/token/RedisTokenInvalidationService.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/token/RedisTokenInvalidationService.java
@@ -1,0 +1,58 @@
+package com.project.likelion14thbe.global.security.token;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+public class RedisTokenInvalidationService implements TokenInvalidationService {
+
+    private static final String KEY_PREFIX = "auth:invalidate-before:";
+
+    private final StringRedisTemplate redisTemplate;
+    private final long refreshExpMs;
+
+    public RedisTokenInvalidationService(
+            StringRedisTemplate redisTemplate,
+            @Value("${spring.jwt.token.refresh-expiration-time:1209600000}") long refreshExpMs
+    ) {
+        this.redisTemplate = redisTemplate;
+        this.refreshExpMs = refreshExpMs;
+    }
+
+    @Override
+    public void invalidateUser(String email) {
+        String key = KEY_PREFIX + email;
+        long now = System.currentTimeMillis();
+        try {
+            redisTemplate.opsForValue()
+                    .set(key, String.valueOf(now), Duration.ofMillis(refreshExpMs));
+            log.info("[ TokenInvalidation ] 컷오프 기록 : {} = {}", email, now);
+        } catch (DataAccessException e) {
+            // 후속 관측성 phase: Redis 불가 시 메트릭 카운터 hook
+            log.warn("[ TokenInvalidation ] 컷오프 기록 실패(fail-open) : {} : {}", email, e.getMessage());
+        }
+    }
+
+    @Override
+    public boolean isInvalidated(String email, long tokenIatMillis) {
+        String key = KEY_PREFIX + email;
+        try {
+            String cutoffRaw = redisTemplate.opsForValue().get(key);
+            if (cutoffRaw == null) {
+                return false;
+            }
+            long cutoff = Long.parseLong(cutoffRaw);
+            return tokenIatMillis < cutoff;
+        } catch (DataAccessException e) {
+            // 후속 관측성 phase: Redis 불가 시 메트릭 카운터 hook
+            log.warn("[ TokenInvalidation ] 컷오프 조회 실패(fail-open) : {} : {}", email, e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/project/likelion14thbe/global/security/token/RedisTokenInvalidationService.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/token/RedisTokenInvalidationService.java
@@ -25,6 +25,15 @@ public class RedisTokenInvalidationService implements TokenInvalidationService {
         this.refreshExpMs = refreshExpMs;
     }
 
+    /**
+     * 컷오프를 millis로 기록한다. 단, JWT iat는 RFC 7519상 초 단위라
+     * getIssuedAt()은 항상 1000ms 배수다. 따라서 로그아웃과 같은 wall-clock
+     * 초 안에 재로그인하면, 새 토큰 iat(= 그 초의 millis)가 cutoff보다 작아
+     * 최대 약 1초 동안 정상 토큰이 401로 거부될 수 있다. 이는 의도된 수용
+     * 한계다: 보안상 안전한 방향(과다 무효화)으로 실패하며, 로그아웃된
+     * 토큰이 살아남지 않는다. 완전 해소는 per-token jti(후속 S3 범위)로만
+     * 가능하다.
+     */
     @Override
     public void invalidateUser(String email) {
         String key = KEY_PREFIX + email;

--- a/src/main/java/com/project/likelion14thbe/global/security/token/RedisTokenInvalidationService.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/token/RedisTokenInvalidationService.java
@@ -53,6 +53,9 @@ public class RedisTokenInvalidationService implements TokenInvalidationService {
             // 후속 관측성 phase: Redis 불가 시 메트릭 카운터 hook
             log.warn("[ TokenInvalidation ] 컷오프 조회 실패(fail-open) : {} : {}", email, e.getMessage());
             return false;
+        } catch (NumberFormatException e) {
+            log.warn("[ TokenInvalidation ] 컷오프 값 파싱 실패(fail-open) : {} : {}", email, e.getMessage());
+            return false;
         }
     }
 }

--- a/src/main/java/com/project/likelion14thbe/global/security/token/TokenInvalidationService.java
+++ b/src/main/java/com/project/likelion14thbe/global/security/token/TokenInvalidationService.java
@@ -1,0 +1,21 @@
+package com.project.likelion14thbe.global.security.token;
+
+/**
+ * 사용자별 토큰 무효화 컷오프를 기록·조회한다.
+ * 로그아웃·비밀번호 변경·탈퇴가 공통으로 사용한다.
+ */
+public interface TokenInvalidationService {
+
+    /**
+     * 지금 이후로 {email}이 그 전에 발급받은 토큰을 모두 무효화한다.
+     */
+    void invalidateUser(String email);
+
+    /**
+     * 토큰 발급 시각이 컷오프보다 엄격히 이전이면 무효 처리한다.
+     *
+     * @param tokenIatMillis JWT iat (epoch millis)
+     * @return 무효면 true. 키 없음 또는 Redis 장애 시 false(fail-open).
+     */
+    boolean isInvalidated(String email, long tokenIatMillis);
+}


### PR DESCRIPTION
# ☝️ Issue Number

- #91

## 📌 개요

7주차 과제 - 카카오 네이버 OAuth 콜백 로그인과 신규 가입, 로그아웃 토큰 무효화(블랙리스트) 인프라를 도입한다.

## 🔁 변경 사항

### OAuth (카카오/네이버)
- 소셜 신원 도메인(SocialAccount) 과 카카오/네이버 응답 DTO 추가
- 카카오/네이버 전략과 변환기 구현 (state CSRF, email 부재 분기, Provider 별 에러코드)
- OAuth 콜백 로그인과 가입 서비스, 컨트롤러 구현
- OAuth 호출 인프라(WebClient), 에러코드, 시큐리티 화이트리스트 추가

### 토큰 무효화 (블랙리스트)
- Redis 의존성과 토큰 무효화 설정 추가
- 사용자별 토큰 무효화 컷오프 서비스 구현 (RedisTokenInvalidationService)
- 손상된 컷오프 값과 Redis 장애 시 fail-open 보장
- JWT 발급 시각(iat) 추출 메서드 추가
- 무효화된 토큰을 인가 필터(JwtAuthorizationFilter) 에서 거부
- 로그아웃, 비밀번호 변경, 회원 탈퇴 시 토큰 무효화 컷오프를 기록

### 테스트
- 테스트 코드는 PR 범위 외(레포 컨벤션). 로컬 ./gradlew test 로 34 케이스 GREEN 검증.
- build.gradle 의 Testcontainers MySQL 의존성은 로컬 통합 테스트 컴파일 보장용이라 포함.

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점